### PR TITLE
Improve the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
         required: true
         type: boolean
         default: false
-      skip_validation:
-        description: 'Emergency override: set to true only if automated tag/version/release-notes validation is temporarily broken and you have manually verified all release details (use with extreme caution)'
+      skip_release_notes:
+        description: 'Emergency override: set to true only if GitHub Release note lookup is unavailable and you have manually verified the release notes'
         required: true
         type: boolean
         default: false
@@ -29,83 +29,18 @@ jobs:
   checks:
     name: Pre-release validation
     runs-on: ubuntu-latest
+    outputs:
+      npm_access: ${{ steps.release-validation.outputs.npm_access }}
+      npm_dist_tag: ${{ steps.release-validation.outputs.npm_dist_tag }}
+      package_name: ${{ steps.release-validation.outputs.package_name }}
+      release_tag: ${{ steps.release-validation.outputs.release_tag }}
+      release_version: ${{ steps.release-validation.outputs.release_version }}
     env:
       COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Validate release tag and release notes
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.skip_validation)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          # For release events, read tag/body from the event payload.
-          # For workflow_dispatch, require that the run is started on a semver tag ref
-          # and validate release notes by fetching the GitHub Release for that tag.
-          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
-            TAG=$(node --input-type=module -e "import { readFileSync } from 'node:fs'; const e = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); console.log(e.release?.tag_name ?? '');")
-            RELEASE_BODY=$(node --input-type=module -e "import { readFileSync } from 'node:fs'; const e = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); console.log(e.release?.body ?? '');")
-          else
-            if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
-              echo "::error::Manual publish must run on a semver tag ref (refs/tags/vMAJOR.MINOR.PATCH...). In GitHub, go to the Actions tab, open the 'Release' workflow, click 'Run workflow', and in the 'Use workflow from' selector choose the desired tag (e.g. v1.2.3) before re-running."
-              exit 1
-            fi
-
-            TAG="${GITHUB_REF#refs/tags/}"
-
-            # Fetch the corresponding GitHub Release so manual runs still enforce release notes.
-            API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
-            RESPONSE_FILE="release_response.json"
-            HTTP_STATUS=$(curl -sS -L \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              -H "Accept: application/vnd.github+json" \
-              -w "%{http_code}" \
-              -o "${RESPONSE_FILE}" \
-              "${API_URL}")
-
-            if [ "${HTTP_STATUS}" = "404" ]; then
-              echo "::error::No GitHub Release was found for tag '${TAG}'. For manual runs, create a release for this tag (or ensure you're using the correct tag) before publishing."
-              echo "GitHub API URL: ${API_URL}"
-              exit 1
-            elif [ "${HTTP_STATUS}" -lt 200 ] || [ "${HTTP_STATUS}" -ge 300 ]; then
-              echo "::error::Failed to fetch GitHub Release for tag '${TAG}'. HTTP status: ${HTTP_STATUS}"
-              echo "GitHub API URL: ${API_URL}"
-              echo "Response body:"
-              cat "${RESPONSE_FILE}" || true
-              exit 1
-            fi
-
-            RELEASE_BODY=$(node --input-type=module -e "import { readFileSync } from 'node:fs'; const r = JSON.parse(readFileSync(process.env.RESPONSE_FILE, 'utf8')); console.log(r.body ?? '');" RESPONSE_FILE="${RESPONSE_FILE}")
-          fi
-
-          if [ -z "${TAG}" ]; then
-            echo "::error::Unable to determine release tag for validation."
-            exit 1
-          fi
-
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
-            echo "::error::Release tag '$TAG' does not match semver policy (expected vMAJOR.MINOR.PATCH with optional prerelease, e.g. v1.2.3 or v1.2.3-rc.1)."
-            exit 1
-          fi
-
-          # Enforce human-readable release notes (non-empty, non-whitespace body).
-          if [ -z "$(printf '%s' "$RELEASE_BODY" | tr -d '[:space:]')" ]; then
-            echo "::error::Release notes are required (GitHub Release body is empty/whitespace)."
-            exit 1
-          fi
-
-          # Verify package.json version matches release tag.
-          PKG_VERSION=$(node --input-type=module -e "import { readFileSync } from 'node:fs'; console.log(JSON.parse(readFileSync('./package.json', 'utf8')).version);")
-          TAG_VERSION="${TAG#v}"  # Strip leading 'v'
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Version mismatch: package.json has $PKG_VERSION but release tag is $TAG (expected v$PKG_VERSION)."
-            exit 1
-          fi
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -131,6 +66,21 @@ jobs:
 
       - name: Install dependencies (immutable, with fallback)
         run: bash ./scripts/yarn-install-immutable.sh
+
+      - name: Validate release metadata
+        id: release-validation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_RELEASE_NOTES: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_release_notes || false }}
+        run: |
+          set -euo pipefail
+
+          args=()
+          if [ "${SKIP_RELEASE_NOTES}" = "true" ]; then
+            args+=(--skip-release-notes)
+          fi
+
+          yarn release:validate "${args[@]}"
 
       - name: Run pre-release validation
         run: yarn prerelease
@@ -181,16 +131,60 @@ jobs:
             exit 1
           fi
 
-      - name: Determine npm access flag
+      - name: Summarise publish target
+        env:
+          NPM_ACCESS: ${{ needs.checks.outputs.npm_access }}
+          NPM_DIST_TAG: ${{ needs.checks.outputs.npm_dist_tag }}
+          PACKAGE_NAME: ${{ needs.checks.outputs.package_name }}
+          RELEASE_TAG: ${{ needs.checks.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.checks.outputs.release_version }}
         run: |
-          NAME=$(node --input-type=module -e "import { readFileSync } from 'node:fs'; console.log(JSON.parse(readFileSync('./package.json', 'utf8')).name);")
-          if [[ "$NAME" == @*/* ]]; then
-            echo "NPM_ACCESS=--access public" >> "$GITHUB_ENV"
-          else
-            echo "NPM_ACCESS=" >> "$GITHUB_ENV"
+          set -euo pipefail
+
+          dry_run_command="npm publish --tag ${NPM_DIST_TAG} --provenance --dry-run"
+          publish_command="npm publish --tag ${NPM_DIST_TAG} --provenance"
+          if [ -n "${NPM_ACCESS}" ]; then
+            dry_run_command="npm publish --access ${NPM_ACCESS} --tag ${NPM_DIST_TAG} --provenance --dry-run"
+            publish_command="npm publish --access ${NPM_ACCESS} --tag ${NPM_DIST_TAG} --provenance"
           fi
+
+          {
+            echo '## Publish target'
+            echo ''
+            echo "- Package: \`${PACKAGE_NAME}\`"
+            echo "- Version: \`${RELEASE_VERSION}\`"
+            echo "- Tag: \`${RELEASE_TAG}\`"
+            echo "- npm dist-tag: \`${NPM_DIST_TAG}\`"
+            echo "- Dry-run command: \`${dry_run_command}\`"
+            echo "- Publish command: \`${publish_command}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish dry run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_ACCESS: ${{ needs.checks.outputs.npm_access }}
+          NPM_DIST_TAG: ${{ needs.checks.outputs.npm_dist_tag }}
+        run: |
+          set -euo pipefail
+
+          publish_args=(--tag "${NPM_DIST_TAG}" --provenance)
+          if [ -n "${NPM_ACCESS}" ]; then
+            publish_args+=(--access "${NPM_ACCESS}")
+          fi
+
+          npm publish "${publish_args[@]}" --dry-run
 
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish ${NPM_ACCESS:-} --provenance
+          NPM_ACCESS: ${{ needs.checks.outputs.npm_access }}
+          NPM_DIST_TAG: ${{ needs.checks.outputs.npm_dist_tag }}
+        run: |
+          set -euo pipefail
+
+          publish_args=(--tag "${NPM_DIST_TAG}" --provenance)
+          if [ -n "${NPM_ACCESS}" ]; then
+            publish_args+=(--access "${NPM_ACCESS}")
+          fi
+
+          npm publish "${publish_args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ node_modules
 # Packed tarballs (npm pack / yarn pack)
 *.tgz
 
+# Generated local release notes
+.release-notes/
+
 # Logs
 *.log
 

--- a/.npmignore
+++ b/.npmignore
@@ -19,6 +19,7 @@ coverage/
 # Packed tarballs
 
 *.tgz
+.release-notes/
 
 # OS / editor noise
 
@@ -35,6 +36,7 @@ specs/
 .codex/
 .specify/
 scripts/prerelease/
+scripts/release/
 .editorconfig
 .prettierignore
 .prettierrc.js

--- a/README.md
+++ b/README.md
@@ -114,18 +114,50 @@ This repo uses **ShellCheck** to lint repository-tracked `*.sh` scripts.
 
 - Avoid global disables in `.shellcheckrc`.
 
-## Releasing
+## 🚀 Releasing
 
 Publishing is **GitHub Release-driven**.
 
-### Prerequisites
+### ✅ Prerequisites
 
 - Configure the repository secret `NPM_TOKEN` with an npm automation token that has publish rights for `@smolpack/eslint-config`.
 
-### Release flow
+### 🧭 Release flow
 
-1. Bump `package.json#version` and commit.
-2. Run `yarn prerelease` locally to validate linting, packaging, and import smoke tests.
-3. Create a semver tag like `vX.Y.Z` (or prerelease `vX.Y.Z-rc.1`) pointing at that commit.
-4. Create a GitHub Release for that tag and include human-readable release notes.
-5. GitHub Actions runs `.github/workflows/release.yml` to validate and publish.
+1. Prepare the local release commit, tag, and notes:
+
+   ```bash
+   yarn release:prepare 1.2.3
+   ```
+
+   Use prerelease versions such as `1.2.3-rc.1` when needed. The helper updates `package.json`, runs `yarn prerelease`, creates `Release vX.Y.Z`, creates an annotated `vX.Y.Z` tag, and writes notes to `.release-notes/vX.Y.Z.md`.
+
+2. Push the release commit and tag:
+
+   ```bash
+   git push origin HEAD
+   git push origin v1.2.3
+   ```
+
+3. Create the GitHub Release using the generated notes:
+
+   ```bash
+   gh release create v1.2.3 --notes-file .release-notes/v1.2.3.md
+   ```
+
+   You can also create the release in the GitHub UI, but the release body must contain human-readable notes.
+
+4. GitHub Actions runs `.github/workflows/release.yml`, validates the tag, release notes, package version, package contents, and import smoke test, then publishes to npm.
+
+Stable versions publish to npm’s `latest` dist-tag. Prerelease versions publish to `next`, so release candidates do not replace the default install target.
+
+### 🧯 Local rollback
+
+If you have not pushed the release commit or tag yet, roll back with:
+
+```bash
+git tag -d v1.2.3
+git reset --soft HEAD~1
+```
+
+After pushing, avoid rewriting public history. Fix problems with a follow-up release.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Publishing is **GitHub Release-driven**.
 
 ### ✅ Prerequisites
 
-- Configure the repository secret `NPM_TOKEN` with an npm automation token that has publish rights for `@smolpack/eslint-config`.
+- Configure the repository secret `NPM_TOKEN` with an npm automation token that has publishing rights for `@smolpack/eslint-config`.
 
 ### 🧭 Release flow
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Publishing is **GitHub Release-driven**.
 
    You can also create the release in the GitHub UI, but the release body must contain human-readable notes.
 
-4. GitHub Actions runs `.github/workflows/release.yml`, validates the tag, release notes, package version, package contents, and import smoke test, then publishes to npm.
+4. GitHub Actions runs `.github/workflows/release.yml`, validates the tag, release notes, package version, package contents, and import smoke test by default, then publishes to npm. For manual runs, `skip_release_notes=true` bypasses only the release-notes check.
 
 Stable versions publish to npm’s `latest` dist-tag. Prerelease versions publish to `next`, so release candidates do not replace the default install target.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SmolSoftBoi/eslint-config.git"
+    "url": "git+https://github.com/SmolSoftBoi/eslint-config.git"
   },
   "type": "module",
   "main": "index.mjs",
@@ -19,6 +19,9 @@
     "smoke:import": "node ./scripts/prerelease/smoke-import.mjs",
     "smoke:pack": "bash ./scripts/smoke-import-packed.sh",
     "prerelease": "yarn preflight && yarn pack:check && yarn smoke:import",
+    "release:validate": "node ./scripts/release/validate.mjs",
+    "release:notes": "node ./scripts/release/notes.mjs",
+    "release:prepare": "node ./scripts/release/prepare.mjs",
     "prepublishOnly": "yarn prerelease"
   },
   "keywords": [

--- a/scripts/prerelease/utils.mjs
+++ b/scripts/prerelease/utils.mjs
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
+import os from 'node:os';
 import path from 'node:path';
 
 const execFileAsync = promisify(execFile);
@@ -252,7 +253,10 @@ function resolveNpmCommand() {
   const env = {
     ...process.env,
     COREPACK_ENABLE_PROJECT_SPEC: '0',
-    COREPACK_ENABLE_STRICT: '0'
+    COREPACK_ENABLE_STRICT: '0',
+    npm_config_dry_run: 'false',
+    npm_config_cache:
+      process.env.npm_config_cache ?? path.join(os.tmpdir(), 'eslint-config-npm-cache')
   };
 
   if (execPath && /\.(c?m?js)$/i.test(execPath)) {

--- a/scripts/release/core.mjs
+++ b/scripts/release/core.mjs
@@ -122,7 +122,7 @@ export async function fetchGitHubReleaseBody({
     headers: {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28'
+      'X-GitHub-Api-Version': '2026-03-10'
     }
   });
 

--- a/scripts/release/core.mjs
+++ b/scripts/release/core.mjs
@@ -156,11 +156,17 @@ export async function resolveReleaseContext({
   token = process.env.GITHUB_TOKEN
 } = {}) {
   if (tag) {
+    if (!skipReleaseNotes) {
+      throw new Error(
+        'Explicit --tag validation does not fetch GitHub Release notes. Re-run with --skip-release-notes after manually verifying release notes, or validate from a release/workflow_dispatch event.'
+      );
+    }
+
     return {
       tag,
       releaseBody: '',
-      requireReleaseNotes: !skipReleaseNotes,
-      releaseNotesStatus: skipReleaseNotes ? 'skipped' : 'not provided'
+      requireReleaseNotes: false,
+      releaseNotesStatus: 'skipped by explicit tag override'
     };
   }
 

--- a/scripts/release/core.mjs
+++ b/scripts/release/core.mjs
@@ -1,0 +1,260 @@
+import { appendFile, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const releaseTagPattern =
+  /^v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/;
+
+export const versionPattern =
+  /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export function isReleaseVersion(version) {
+  return typeof version === 'string' && versionPattern.test(version);
+}
+
+export function normalizeVersionInput(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error('Release version is required.');
+  }
+
+  const trimmed = value.trim();
+  return trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+}
+
+export function parseReleaseTag(tag) {
+  if (typeof tag !== 'string' || !tag.trim()) {
+    throw new Error('Release tag is required.');
+  }
+
+  const match = releaseTagPattern.exec(tag.trim());
+  if (!match?.groups?.version) {
+    throw new Error(
+      `Release tag '${tag}' does not match semver policy (expected vMAJOR.MINOR.PATCH with optional prerelease, e.g. v1.2.3 or v1.2.3-rc.1).`
+    );
+  }
+
+  return {
+    tag: tag.trim(),
+    version: match.groups.version
+  };
+}
+
+export function getNpmDistTagForVersion(version) {
+  if (!isReleaseVersion(version)) {
+    throw new Error(`Package version '${version}' is not a valid release version.`);
+  }
+
+  return version.includes('-') ? 'next' : 'latest';
+}
+
+export function getNpmAccessForPackage(packageName) {
+  return typeof packageName === 'string' && packageName.startsWith('@') ? 'public' : '';
+}
+
+export function validateReleaseFields({
+  packageName,
+  packageVersion,
+  releaseBody,
+  requireReleaseNotes = true,
+  tag
+}) {
+  const parsedTag = parseReleaseTag(tag);
+
+  if (packageVersion !== parsedTag.version) {
+    throw new Error(
+      `Version mismatch: package.json has ${packageVersion} but release tag is ${parsedTag.tag} (expected v${packageVersion}).`
+    );
+  }
+
+  if (requireReleaseNotes && !String(releaseBody ?? '').trim()) {
+    throw new Error('Release notes are required (GitHub Release body is empty/whitespace).');
+  }
+
+  const npmDistTag = getNpmDistTagForVersion(packageVersion);
+  const npmAccess = getNpmAccessForPackage(packageName);
+
+  return {
+    packageName,
+    tag: parsedTag.tag,
+    version: packageVersion,
+    npmDistTag,
+    npmAccess,
+    releaseNotesStatus: requireReleaseNotes ? 'validated' : 'skipped'
+  };
+}
+
+export async function loadPackageJson(cwd = process.cwd()) {
+  const filePath = path.join(cwd, 'package.json');
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+export async function readReleaseEvent(eventPath) {
+  if (!eventPath) {
+    throw new Error('GITHUB_EVENT_PATH is required for release event validation.');
+  }
+
+  const event = JSON.parse(await readFile(eventPath, 'utf8'));
+  return {
+    tag: event.release?.tag_name ?? '',
+    body: event.release?.body ?? ''
+  };
+}
+
+export async function fetchGitHubReleaseBody({
+  fetchImpl = globalThis.fetch,
+  repository,
+  tag,
+  token
+}) {
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required to fetch release notes for manual publish.');
+  }
+
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required to fetch release notes for manual publish.');
+  }
+
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required to fetch GitHub release notes.');
+  }
+
+  const apiUrl = `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`;
+  const response = await fetchImpl(apiUrl, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+
+  if (response.status === 404) {
+    throw new Error(
+      `No GitHub Release was found for tag '${tag}'. Create a release for this tag before publishing.`
+    );
+  }
+
+  if (!response.ok) {
+    const responseText = typeof response.text === 'function' ? await response.text() : '';
+    throw new Error(
+      `Failed to fetch GitHub Release for tag '${tag}'. HTTP status: ${response.status}${
+        responseText ? `; response: ${responseText}` : ''
+      }`
+    );
+  }
+
+  const release = await response.json();
+  return release.body ?? '';
+}
+
+export async function resolveReleaseContext({
+  eventName = process.env.GITHUB_EVENT_NAME,
+  eventPath = process.env.GITHUB_EVENT_PATH,
+  fetchImpl = globalThis.fetch,
+  ref = process.env.GITHUB_REF,
+  repository = process.env.GITHUB_REPOSITORY,
+  skipReleaseNotes = false,
+  tag,
+  token = process.env.GITHUB_TOKEN
+} = {}) {
+  if (tag) {
+    return {
+      tag,
+      releaseBody: '',
+      requireReleaseNotes: !skipReleaseNotes,
+      releaseNotesStatus: skipReleaseNotes ? 'skipped' : 'not provided'
+    };
+  }
+
+  if (eventName === 'release') {
+    const release = await readReleaseEvent(eventPath);
+    return {
+      tag: release.tag,
+      releaseBody: release.body,
+      requireReleaseNotes: true,
+      releaseNotesStatus: 'event payload'
+    };
+  }
+
+  if (eventName === 'workflow_dispatch') {
+    if (!ref?.startsWith('refs/tags/')) {
+      throw new Error(
+        'Manual publish must run on a semver tag ref. In GitHub Actions, use the workflow selector to choose the desired tag before running the workflow.'
+      );
+    }
+
+    const manualTag = ref.slice('refs/tags/'.length);
+    if (skipReleaseNotes) {
+      return {
+        tag: manualTag,
+        releaseBody: '',
+        requireReleaseNotes: false,
+        releaseNotesStatus: 'skipped by manual override'
+      };
+    }
+
+    return {
+      tag: manualTag,
+      releaseBody: await fetchGitHubReleaseBody({
+        fetchImpl,
+        repository,
+        tag: manualTag,
+        token
+      }),
+      requireReleaseNotes: true,
+      releaseNotesStatus: 'fetched from GitHub Release'
+    };
+  }
+
+  throw new Error(`Unsupported release validation event '${eventName ?? '<unset>'}'.`);
+}
+
+export function formatPublishCommand({ npmAccess, npmDistTag, dryRun = false }) {
+  const args = ['npm publish'];
+
+  if (npmAccess) {
+    args.push(`--access ${npmAccess}`);
+  }
+
+  args.push(`--tag ${npmDistTag}`, '--provenance');
+
+  if (dryRun) {
+    args.push('--dry-run');
+  }
+
+  return args.join(' ');
+}
+
+export function formatValidationSummary(result) {
+  const dryRunCommand = formatPublishCommand({ ...result, dryRun: true });
+  const publishCommand = formatPublishCommand(result);
+
+  return [
+    '## Release validation',
+    '',
+    `- Package: \`${result.packageName}\``,
+    `- Version: \`${result.version}\``,
+    `- Tag: \`${result.tag}\``,
+    `- npm dist-tag: \`${result.npmDistTag}\``,
+    `- Release notes: ${result.releaseNotesStatus}`,
+    `- Validation: ${result.validationStatus ?? 'passed'}`,
+    `- Dry-run command: \`${dryRunCommand}\``,
+    `- Publish command: \`${publishCommand}\``,
+    ''
+  ].join('\n');
+}
+
+export async function appendGitHubOutput(outputs, outputPath = process.env.GITHUB_OUTPUT) {
+  if (!outputPath) {
+    return;
+  }
+
+  const lines = Object.entries(outputs).map(([key, value]) => `${key}=${value ?? ''}`);
+  await appendFile(outputPath, `${lines.join('\n')}\n`);
+}
+
+export async function appendGitHubSummary(summary, summaryPath = process.env.GITHUB_STEP_SUMMARY) {
+  if (!summaryPath) {
+    return;
+  }
+
+  await appendFile(summaryPath, summary);
+}

--- a/scripts/release/core.test.mjs
+++ b/scripts/release/core.test.mjs
@@ -9,6 +9,7 @@ import {
   resolveReleaseContext,
   validateReleaseFields
 } from './core.mjs';
+import { parseArgs } from './validate.mjs';
 
 test('parseReleaseTag accepts stable and prerelease tags', () => {
   assert.deepEqual(parseReleaseTag('v1.2.3'), {
@@ -56,6 +57,49 @@ test('validateReleaseFields rejects empty release notes when required', () => {
 test('getNpmDistTagForVersion maps stable releases to latest and prereleases to next', () => {
   assert.equal(getNpmDistTagForVersion('1.2.3'), 'latest');
   assert.equal(getNpmDistTagForVersion('1.2.3-rc.1'), 'next');
+});
+
+test('parseArgs accepts both release validation tag forms', () => {
+  assert.deepEqual(parseArgs(['--tag=v1.2.3', '--skip-release-notes']), {
+    skipReleaseNotes: true,
+    tag: 'v1.2.3'
+  });
+
+  assert.deepEqual(parseArgs(['--tag', 'v1.2.3-rc.1', '--skip-release-notes']), {
+    skipReleaseNotes: true,
+    tag: 'v1.2.3-rc.1'
+  });
+});
+
+test('parseArgs rejects --tag without a value', () => {
+  assert.throws(() => parseArgs(['--tag']), /--tag option requires a value/u);
+});
+
+test('resolveReleaseContext fails fast for explicit tag validation without release-note skip', async () => {
+  await assert.rejects(
+    () =>
+      resolveReleaseContext({
+        eventName: 'workflow_dispatch',
+        ref: 'refs/tags/v1.2.3',
+        tag: 'v1.2.3'
+      }),
+    /Explicit --tag validation does not fetch GitHub Release notes/u
+  );
+});
+
+test('resolveReleaseContext supports explicit tag validation when release notes are skipped', async () => {
+  assert.deepEqual(
+    await resolveReleaseContext({
+      skipReleaseNotes: true,
+      tag: 'v1.2.3'
+    }),
+    {
+      releaseBody: '',
+      releaseNotesStatus: 'skipped by explicit tag override',
+      requireReleaseNotes: false,
+      tag: 'v1.2.3'
+    }
+  );
 });
 
 test('resolveReleaseContext reads release event tag and body', async () => {

--- a/scripts/release/core.test.mjs
+++ b/scripts/release/core.test.mjs
@@ -73,6 +73,7 @@ test('parseArgs accepts both release validation tag forms', () => {
 
 test('parseArgs rejects --tag without a value', () => {
   assert.throws(() => parseArgs(['--tag']), /--tag option requires a value/u);
+  assert.throws(() => parseArgs(['--tag=']), /--tag option requires a value/u);
 });
 
 test('resolveReleaseContext fails fast for explicit tag validation without release-note skip', async () => {
@@ -164,6 +165,7 @@ test('resolveReleaseContext fetches GitHub Release notes for manual dispatch', a
     'https://api.github.com/repos/SmolSoftBoi/eslint-config/releases/tags/v1.2.3'
   );
   assert.equal(calls[0].options.headers.Authorization, 'Bearer token');
+  assert.equal(calls[0].options.headers['X-GitHub-Api-Version'], '2026-03-10');
 });
 
 test('resolveReleaseContext only skips release-note lookup for manual override', async () => {

--- a/scripts/release/core.test.mjs
+++ b/scripts/release/core.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  getNpmDistTagForVersion,
+  parseReleaseTag,
+  resolveReleaseContext,
+  validateReleaseFields
+} from './core.mjs';
+
+test('parseReleaseTag accepts stable and prerelease tags', () => {
+  assert.deepEqual(parseReleaseTag('v1.2.3'), {
+    tag: 'v1.2.3',
+    version: '1.2.3'
+  });
+
+  assert.deepEqual(parseReleaseTag('v1.2.3-rc.1'), {
+    tag: 'v1.2.3-rc.1',
+    version: '1.2.3-rc.1'
+  });
+});
+
+test('parseReleaseTag rejects non-semver tags', () => {
+  assert.throws(() => parseReleaseTag('v1'), /does not match semver policy/u);
+  assert.throws(() => parseReleaseTag('release-1.2.3'), /does not match semver policy/u);
+});
+
+test('validateReleaseFields rejects a package version mismatch', () => {
+  assert.throws(
+    () =>
+      validateReleaseFields({
+        packageName: '@smolpack/eslint-config',
+        packageVersion: '1.2.3',
+        releaseBody: 'Release notes',
+        tag: 'v1.2.4'
+      }),
+    /Version mismatch/u
+  );
+});
+
+test('validateReleaseFields rejects empty release notes when required', () => {
+  assert.throws(
+    () =>
+      validateReleaseFields({
+        packageName: '@smolpack/eslint-config',
+        packageVersion: '1.2.3',
+        releaseBody: '   ',
+        tag: 'v1.2.3'
+      }),
+    /Release notes are required/u
+  );
+});
+
+test('getNpmDistTagForVersion maps stable releases to latest and prereleases to next', () => {
+  assert.equal(getNpmDistTagForVersion('1.2.3'), 'latest');
+  assert.equal(getNpmDistTagForVersion('1.2.3-rc.1'), 'next');
+});
+
+test('resolveReleaseContext reads release event tag and body', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-event-'));
+  const eventPath = path.join(tempDir, 'event.json');
+
+  try {
+    await writeFile(
+      eventPath,
+      JSON.stringify({
+        release: {
+          body: 'Human release notes',
+          tag_name: 'v1.2.3'
+        }
+      })
+    );
+
+    assert.deepEqual(
+      await resolveReleaseContext({
+        eventName: 'release',
+        eventPath
+      }),
+      {
+        releaseBody: 'Human release notes',
+        releaseNotesStatus: 'event payload',
+        requireReleaseNotes: true,
+        tag: 'v1.2.3'
+      }
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('resolveReleaseContext fetches GitHub Release notes for manual dispatch', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ options, url });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { body: 'Fetched release notes' };
+      }
+    };
+  };
+
+  const context = await resolveReleaseContext({
+    eventName: 'workflow_dispatch',
+    fetchImpl,
+    ref: 'refs/tags/v1.2.3',
+    repository: 'SmolSoftBoi/eslint-config',
+    token: 'token'
+  });
+
+  assert.equal(context.tag, 'v1.2.3');
+  assert.equal(context.releaseBody, 'Fetched release notes');
+  assert.equal(context.requireReleaseNotes, true);
+  assert.equal(context.releaseNotesStatus, 'fetched from GitHub Release');
+  assert.equal(
+    calls[0].url,
+    'https://api.github.com/repos/SmolSoftBoi/eslint-config/releases/tags/v1.2.3'
+  );
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer token');
+});
+
+test('resolveReleaseContext only skips release-note lookup for manual override', async () => {
+  const context = await resolveReleaseContext({
+    eventName: 'workflow_dispatch',
+    fetchImpl: async () => {
+      throw new Error('fetch should not be called');
+    },
+    ref: 'refs/tags/v1.2.3-rc.1',
+    repository: 'SmolSoftBoi/eslint-config',
+    skipReleaseNotes: true,
+    token: 'token'
+  });
+
+  assert.deepEqual(context, {
+    releaseBody: '',
+    releaseNotesStatus: 'skipped by manual override',
+    requireReleaseNotes: false,
+    tag: 'v1.2.3-rc.1'
+  });
+});

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -18,6 +18,20 @@ function compareNumbers(left, right) {
   return Math.sign(left - right);
 }
 
+function compareAscii(left, right) {
+  const length = Math.min(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const characterComparison = compareNumbers(left.charCodeAt(index), right.charCodeAt(index));
+
+    if (characterComparison !== 0) {
+      return characterComparison;
+    }
+  }
+
+  return compareNumbers(left.length, right.length);
+}
+
 function parseComparableTag(tag) {
   const { version } = parseReleaseTag(tag);
   const prereleaseStartIndex = version.indexOf('-');
@@ -52,7 +66,7 @@ function comparePrereleaseIdentifiers(left, right) {
     return 1;
   }
 
-  return left.localeCompare(right);
+  return compareAscii(left, right);
 }
 
 function compareParsedTags(left, right) {

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -20,7 +20,11 @@ function compareNumbers(left, right) {
 
 function parseComparableTag(tag) {
   const { version } = parseReleaseTag(tag);
-  const [coreVersion, prereleaseVersion = ''] = version.split('-');
+  const prereleaseStartIndex = version.indexOf('-');
+  const coreVersion =
+    prereleaseStartIndex === -1 ? version : version.slice(0, prereleaseStartIndex);
+  const prereleaseVersion =
+    prereleaseStartIndex === -1 ? '' : version.slice(prereleaseStartIndex + 1);
   const [major, minor, patch] = coreVersion.split('.').map(Number);
 
   return {

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -1,0 +1,147 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { loadPackageJson, normalizeVersionInput, parseReleaseTag } from './core.mjs';
+
+function runGit(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+export function getSemverTags({ cwd = process.cwd(), run = runGit } = {}) {
+  const output = run(['tag', '--list', 'v*', '--sort=-v:refname'], cwd);
+  return output
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .filter((tag) => {
+      try {
+        parseReleaseTag(tag);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+}
+
+export function getPreviousReleaseTag({ currentTag, cwd = process.cwd(), run = runGit } = {}) {
+  return getSemverTags({ cwd, run }).find((tag) => tag !== currentTag) ?? null;
+}
+
+export function getCommitSubjects({ cwd = process.cwd(), fromTag = null, run = runGit } = {}) {
+  const range = fromTag ? `${fromTag}..HEAD` : 'HEAD';
+  const output = run(['log', '--format=%s', range], cwd);
+
+  return output
+    .split('\n')
+    .map((subject) => subject.trim())
+    .filter(Boolean);
+}
+
+export function formatReleaseNotes({
+  commits,
+  currentTag,
+  packageName,
+  previousTag,
+  version
+}) {
+  const lines = [`# ${packageName} ${currentTag}`, '', `Version: \`${version}\``, ''];
+
+  if (previousTag) {
+    lines.push(`Changes since \`${previousTag}\`:`, '');
+  } else {
+    lines.push('Changes in this release:', '');
+  }
+
+  lines.push('## Changes', '');
+
+  if (commits.length > 0) {
+    for (const subject of commits) {
+      lines.push(`- ${subject}`);
+    }
+  } else if (previousTag) {
+    lines.push(`- No committed changes since ${previousTag}.`);
+  } else {
+    lines.push('- Initial release notes generated from the current repository state.');
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export async function generateReleaseNotes({
+  cwd = process.cwd(),
+  outputPath = null,
+  run = runGit,
+  version
+} = {}) {
+  const pkg = await loadPackageJson(cwd);
+  const releaseVersion = normalizeVersionInput(version ?? pkg.version);
+  const currentTag = `v${releaseVersion}`;
+  const previousTag = getPreviousReleaseTag({ currentTag, cwd, run });
+  const commits = getCommitSubjects({ cwd, fromTag: previousTag, run });
+  const notes = formatReleaseNotes({
+    commits,
+    currentTag,
+    packageName: pkg.name,
+    previousTag,
+    version: releaseVersion
+  });
+
+  if (outputPath) {
+    const resolvedOutputPath = path.resolve(cwd, outputPath);
+    await mkdir(path.dirname(resolvedOutputPath), { recursive: true });
+    await writeFile(resolvedOutputPath, notes);
+  }
+
+  return {
+    currentTag,
+    notes,
+    outputPath,
+    previousTag
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    outputPath: null,
+    version: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--output') {
+      args.outputPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--version') {
+      args.version = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (!args.version) {
+      args.version = arg;
+    }
+  }
+
+  return args;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const { outputPath, version } = parseArgs(process.argv.slice(2));
+    const { notes } = await generateReleaseNotes({ outputPath, version });
+    process.stdout.write(notes);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -12,8 +12,95 @@ function runGit(args, cwd) {
   }).trim();
 }
 
+const numericIdentifierPattern = /^[0-9]+$/u;
+
+function compareNumbers(left, right) {
+  return Math.sign(left - right);
+}
+
+function parseComparableTag(tag) {
+  const { version } = parseReleaseTag(tag);
+  const [coreVersion, prereleaseVersion = ''] = version.split('-');
+  const [major, minor, patch] = coreVersion.split('.').map(Number);
+
+  return {
+    major,
+    minor,
+    patch,
+    prerelease: prereleaseVersion ? prereleaseVersion.split('.') : [],
+    tag
+  };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  const leftIsNumeric = numericIdentifierPattern.test(left);
+  const rightIsNumeric = numericIdentifierPattern.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return compareNumbers(Number(left), Number(right));
+  }
+
+  if (leftIsNumeric) {
+    return -1;
+  }
+
+  if (rightIsNumeric) {
+    return 1;
+  }
+
+  return left.localeCompare(right);
+}
+
+function compareParsedTags(left, right) {
+  const coreComparison =
+    compareNumbers(left.major, right.major) ||
+    compareNumbers(left.minor, right.minor) ||
+    compareNumbers(left.patch, right.patch);
+
+  if (coreComparison !== 0) {
+    return coreComparison;
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const identifierComparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
+    if (identifierComparison !== 0) {
+      return identifierComparison;
+    }
+  }
+
+  return 0;
+}
+
+function isStableTag(parsedTag) {
+  return parsedTag.prerelease.length === 0;
+}
+
 export function getSemverTags({ cwd = process.cwd(), run = runGit } = {}) {
-  const output = run(['tag', '--list', 'v*', '--sort=-v:refname'], cwd);
+  const output = run(['tag', '--list', 'v*'], cwd);
   return output
     .split('\n')
     .map((tag) => tag.trim())
@@ -25,11 +112,20 @@ export function getSemverTags({ cwd = process.cwd(), run = runGit } = {}) {
       } catch {
         return false;
       }
-    });
+    })
+    .sort((left, right) => compareParsedTags(parseComparableTag(right), parseComparableTag(left)));
 }
 
 export function getPreviousReleaseTag({ currentTag, cwd = process.cwd(), run = runGit } = {}) {
-  return getSemverTags({ cwd, run }).find((tag) => tag !== currentTag) ?? null;
+  const current = parseComparableTag(currentTag);
+  const candidates = getSemverTags({ cwd, run })
+    .filter((tag) => tag !== currentTag)
+    .map((tag) => parseComparableTag(tag))
+    .filter((candidate) => compareParsedTags(candidate, current) < 0)
+    .filter((candidate) => !isStableTag(current) || isStableTag(candidate))
+    .sort((left, right) => compareParsedTags(right, left));
+
+  return candidates[0]?.tag ?? null;
 }
 
 export function getCommitSubjects({ cwd = process.cwd(), fromTag = null, run = runGit } = {}) {

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -261,9 +261,16 @@ export function parseArgs(argv) {
       continue;
     }
 
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown option ${arg}.`);
+    }
+
     if (!args.version) {
       args.version = arg;
+      continue;
     }
+
+    throw new Error(`Unexpected argument ${arg}.`);
   }
 
   return args;

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -128,8 +128,13 @@ export function getPreviousReleaseTag({ currentTag, cwd = process.cwd(), run = r
   return candidates[0]?.tag ?? null;
 }
 
-export function getCommitSubjects({ cwd = process.cwd(), fromTag = null, run = runGit } = {}) {
-  const range = fromTag ? `${fromTag}..HEAD` : 'HEAD';
+export function getCommitSubjects({
+  cwd = process.cwd(),
+  fromTag = null,
+  run = runGit,
+  toRef = null
+} = {}) {
+  const range = fromTag ? `${fromTag}..${toRef ?? 'HEAD'}` : (toRef ?? 'HEAD');
   const output = run(['log', '--format=%s', range], cwd);
 
   return output
@@ -179,7 +184,13 @@ export async function generateReleaseNotes({
   const releaseVersion = normalizeVersionInput(version ?? pkg.version);
   const currentTag = `v${releaseVersion}`;
   const previousTag = getPreviousReleaseTag({ currentTag, cwd, run });
-  const commits = getCommitSubjects({ cwd, fromTag: previousTag, run });
+  const currentTagExists = getSemverTags({ cwd, run }).includes(currentTag);
+  const commits = getCommitSubjects({
+    cwd,
+    fromTag: previousTag,
+    run,
+    toRef: currentTagExists ? currentTag : null
+  });
   const notes = formatReleaseNotes({
     commits,
     currentTag,
@@ -202,7 +213,16 @@ export async function generateReleaseNotes({
   };
 }
 
-function parseArgs(argv) {
+function readRequiredOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${optionName} option requires a value.`);
+  }
+
+  return value;
+}
+
+export function parseArgs(argv) {
   const args = {
     outputPath: null,
     version: null
@@ -212,13 +232,13 @@ function parseArgs(argv) {
     const arg = argv[index];
 
     if (arg === '--output') {
-      args.outputPath = argv[index + 1];
+      args.outputPath = readRequiredOptionValue(argv, index, '--output');
       index += 1;
       continue;
     }
 
     if (arg === '--version') {
-      args.version = argv[index + 1];
+      args.version = readRequiredOptionValue(argv, index, '--version');
       index += 1;
       continue;
     }
@@ -231,7 +251,7 @@ function parseArgs(argv) {
   return args;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
     const { outputPath, version } = parseArgs(process.argv.slice(2));
     const { notes } = await generateReleaseNotes({ outputPath, version });

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -190,3 +190,50 @@ test('getPreviousReleaseTag uses the nearest previous tag for prereleases', asyn
     await rm(tempDir, { force: true, recursive: true });
   }
 });
+
+test('getPreviousReleaseTag preserves hyphenated prerelease identifiers', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'hyphenated-prerelease-notes-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: '@smolpack/eslint-config',
+        version: '1.1.0-alpha-b.3'
+      })
+    );
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.0']);
+
+    await writeFile(path.join(tempDir, 'alpha-one.txt'), 'alpha-one\n');
+    git(tempDir, ['add', 'alpha-one.txt']);
+    git(tempDir, ['commit', '-m', 'First alpha-b prerelease']);
+    git(tempDir, ['tag', 'v1.1.0-alpha-b.1']);
+
+    await writeFile(path.join(tempDir, 'alpha-two.txt'), 'alpha-two\n');
+    git(tempDir, ['add', 'alpha-two.txt']);
+    git(tempDir, ['commit', '-m', 'Second alpha-b prerelease']);
+    git(tempDir, ['tag', 'v1.1.0-alpha-b.2']);
+
+    await writeFile(path.join(tempDir, 'alpha-three.txt'), 'alpha-three\n');
+    git(tempDir, ['add', 'alpha-three.txt']);
+    git(tempDir, ['commit', '-m', 'Third alpha-b prerelease']);
+
+    const result = await generateReleaseNotes({
+      cwd: tempDir,
+      version: '1.1.0-alpha-b.3'
+    });
+
+    assert.equal(result.previousTag, 'v1.1.0-alpha-b.2');
+    assert.match(result.notes, /- Third alpha-b prerelease/u);
+    assert.doesNotMatch(result.notes, /- First alpha-b prerelease/u);
+    assert.doesNotMatch(result.notes, /- Second alpha-b prerelease/u);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -115,6 +115,30 @@ test('parseArgs requires values for release notes options', () => {
   );
 });
 
+test('parseArgs accepts supported release notes options', () => {
+  assert.deepEqual(parseArgs(['1.2.3']), {
+    outputPath: null,
+    version: '1.2.3'
+  });
+  assert.deepEqual(parseArgs(['--version', '1.2.3']), {
+    outputPath: null,
+    version: '1.2.3'
+  });
+  assert.deepEqual(parseArgs(['--output', 'notes.md']), {
+    outputPath: 'notes.md',
+    version: null
+  });
+  assert.deepEqual(parseArgs(['1.2.3', '--output', 'notes.md']), {
+    outputPath: 'notes.md',
+    version: '1.2.3'
+  });
+});
+
+test('parseArgs rejects unknown options and unexpected extra arguments', () => {
+  assert.throws(() => parseArgs(['--outpu', 'notes.md']), /Unknown option --outpu\./u);
+  assert.throws(() => parseArgs(['1.2.3', 'extra']), /Unexpected argument extra\./u);
+});
+
 test('notes module import is safe when process argv script path is unset', () => {
   const moduleUrl = pathToFileURL(path.resolve('scripts/release/notes.mjs')).href;
 

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -4,7 +4,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { generateReleaseNotes, getPreviousReleaseTag } from './notes.mjs';
+import { pathToFileURL } from 'node:url';
+import { generateReleaseNotes, getPreviousReleaseTag, parseArgs } from './notes.mjs';
 
 function git(cwd, args) {
   return execFileSync('git', args, {
@@ -60,7 +61,13 @@ test('getPreviousReleaseTag uses the nearest lower tag when regenerating older r
     git(tempDir, ['config', 'user.email', 'test@example.com']);
     git(tempDir, ['config', 'user.name', 'Release Test']);
 
-    await writeFile(path.join(tempDir, 'package.json'), '{}\n');
+    await writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: '@smolpack/eslint-config',
+        version: '1.2.0'
+      })
+    );
     git(tempDir, ['add', 'package.json']);
     git(tempDir, ['commit', '-m', 'Initial release']);
     git(tempDir, ['tag', 'v1.0.0']);
@@ -82,9 +89,46 @@ test('getPreviousReleaseTag uses the nearest lower tag when regenerating older r
       }),
       'v1.0.0'
     );
+
+    const result = await generateReleaseNotes({
+      cwd: tempDir,
+      version: '1.1.0'
+    });
+
+    assert.match(result.notes, /- Release 1\.1\.0/u);
+    assert.doesNotMatch(result.notes, /- Release 1\.2\.0/u);
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }
+});
+
+test('parseArgs requires values for release notes options', () => {
+  assert.throws(() => parseArgs(['--version']), /--version option requires a value/u);
+  assert.throws(
+    () => parseArgs(['--version', '--output', 'notes.md']),
+    /--version option requires a value/u
+  );
+  assert.throws(() => parseArgs(['--output']), /--output option requires a value/u);
+  assert.throws(
+    () => parseArgs(['--output', '--version', '1.2.3']),
+    /--output option requires a value/u
+  );
+});
+
+test('notes module import is safe when process argv script path is unset', () => {
+  const moduleUrl = pathToFileURL(path.resolve('scripts/release/notes.mjs')).href;
+
+  execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `process.argv[1] = undefined; await import(${JSON.stringify(moduleUrl)});`
+    ],
+    {
+      encoding: 'utf8'
+    }
+  );
 });
 
 test('getPreviousReleaseTag ignores prerelease tags for stable release baselines', async () => {

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { generateReleaseNotes } from './notes.mjs';
+
+function git(cwd, args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+test('generateReleaseNotes uses the previous semver tag and commit subjects', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-notes-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: '@smolpack/eslint-config',
+        version: '1.1.0'
+      })
+    );
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.0']);
+
+    await writeFile(path.join(tempDir, 'feature.txt'), 'feature\n');
+    git(tempDir, ['add', 'feature.txt']);
+    git(tempDir, ['commit', '-m', 'Improve release workflow']);
+
+    const result = await generateReleaseNotes({
+      cwd: tempDir,
+      version: '1.1.0'
+    });
+
+    assert.equal(result.currentTag, 'v1.1.0');
+    assert.equal(result.previousTag, 'v1.0.0');
+    assert.match(result.notes, /# @smolpack\/eslint-config v1\.1\.0/u);
+    assert.match(result.notes, /Changes since `v1\.0\.0`:/u);
+    assert.match(result.notes, /- Improve release workflow/u);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { generateReleaseNotes } from './notes.mjs';
+import { generateReleaseNotes, getPreviousReleaseTag } from './notes.mjs';
 
 function git(cwd, args) {
   return execFileSync('git', args, {
@@ -47,6 +47,101 @@ test('generateReleaseNotes uses the previous semver tag and commit subjects', as
     assert.match(result.notes, /# @smolpack\/eslint-config v1\.1\.0/u);
     assert.match(result.notes, /Changes since `v1\.0\.0`:/u);
     assert.match(result.notes, /- Improve release workflow/u);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getPreviousReleaseTag uses the nearest lower tag when regenerating older release notes', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'older-release-notes-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(path.join(tempDir, 'package.json'), '{}\n');
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.0']);
+
+    await writeFile(path.join(tempDir, 'one-one.txt'), 'one-one\n');
+    git(tempDir, ['add', 'one-one.txt']);
+    git(tempDir, ['commit', '-m', 'Release 1.1.0']);
+    git(tempDir, ['tag', 'v1.1.0']);
+
+    await writeFile(path.join(tempDir, 'one-two.txt'), 'one-two\n');
+    git(tempDir, ['add', 'one-two.txt']);
+    git(tempDir, ['commit', '-m', 'Release 1.2.0']);
+    git(tempDir, ['tag', 'v1.2.0']);
+
+    assert.equal(
+      getPreviousReleaseTag({
+        currentTag: 'v1.1.0',
+        cwd: tempDir
+      }),
+      'v1.0.0'
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getPreviousReleaseTag ignores prerelease tags for stable release baselines', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'stable-release-notes-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(path.join(tempDir, 'package.json'), '{}\n');
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.0']);
+
+    await writeFile(path.join(tempDir, 'rc.txt'), 'rc\n');
+    git(tempDir, ['add', 'rc.txt']);
+    git(tempDir, ['commit', '-m', 'Release candidate']);
+    git(tempDir, ['tag', 'v1.1.0-rc.1']);
+
+    assert.equal(
+      getPreviousReleaseTag({
+        currentTag: 'v1.1.0',
+        cwd: tempDir
+      }),
+      'v1.0.0'
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getPreviousReleaseTag uses the nearest previous tag for prereleases', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'prerelease-notes-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(path.join(tempDir, 'package.json'), '{}\n');
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.0']);
+
+    await writeFile(path.join(tempDir, 'rc-one.txt'), 'rc-one\n');
+    git(tempDir, ['add', 'rc-one.txt']);
+    git(tempDir, ['commit', '-m', 'First release candidate']);
+    git(tempDir, ['tag', 'v1.1.0-rc.1']);
+
+    assert.equal(
+      getPreviousReleaseTag({
+        currentTag: 'v1.1.0-rc.2',
+        cwd: tempDir
+      }),
+      'v1.1.0-rc.1'
+    );
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -237,3 +237,44 @@ test('getPreviousReleaseTag preserves hyphenated prerelease identifiers', async 
     await rm(tempDir, { force: true, recursive: true });
   }
 });
+
+test('generateReleaseNotes compares prerelease identifiers with ASCII ordering', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ascii-prerelease-notes-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: '@smolpack/eslint-config',
+        version: '1.2.3-rc.2'
+      })
+    );
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.0']);
+
+    await writeFile(path.join(tempDir, 'upper-prerelease.txt'), 'upper-prerelease\n');
+    git(tempDir, ['add', 'upper-prerelease.txt']);
+    git(tempDir, ['commit', '-m', 'Uppercase prerelease baseline']);
+    git(tempDir, ['tag', 'v1.2.3-Z.1']);
+
+    await writeFile(path.join(tempDir, 'next-rc.txt'), 'next-rc\n');
+    git(tempDir, ['add', 'next-rc.txt']);
+    git(tempDir, ['commit', '-m', 'Next release candidate']);
+
+    const result = await generateReleaseNotes({
+      cwd: tempDir,
+      version: '1.2.3-rc.1'
+    });
+
+    assert.equal(result.previousTag, 'v1.2.3-Z.1');
+    assert.match(result.notes, /- Next release candidate/u);
+    assert.doesNotMatch(result.notes, /- Uppercase prerelease baseline/u);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -1,0 +1,152 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateReleaseNotes } from './notes.mjs';
+import { isReleaseVersion, normalizeVersionInput, parseReleaseTag } from './core.mjs';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptsDir, '../..');
+
+function runGit(args, { cwd = repoRoot } = {}) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+function runOptionalGit(args) {
+  try {
+    return runGit(args);
+  } catch {
+    return '';
+  }
+}
+
+function runGitInherited(args) {
+  execFileSync('git', args, {
+    cwd: repoRoot,
+    stdio: 'inherit'
+  });
+}
+
+function assertCleanWorkingTree() {
+  const status = runGit(['status', '--porcelain']);
+  if (status) {
+    throw new Error('Working tree must be clean before preparing a release.');
+  }
+}
+
+function assertGitIdentityConfigured() {
+  const name = runOptionalGit(['config', '--get', 'user.name']);
+  const email = runOptionalGit(['config', '--get', 'user.email']);
+
+  if (!name || !email) {
+    throw new Error('Git user.name and user.email must be configured before creating a release commit.');
+  }
+}
+
+function assertTagDoesNotExist(tag) {
+  const existing = runGit(['tag', '--list', tag]);
+  if (existing) {
+    throw new Error(`Tag ${tag} already exists.`);
+  }
+}
+
+async function updatePackageVersion(version) {
+  const packagePath = path.join(repoRoot, 'package.json');
+  const originalText = await readFile(packagePath, 'utf8');
+  const pkg = JSON.parse(originalText);
+  pkg.version = version;
+  const updatedText = `${JSON.stringify(pkg, null, 2)}\n`;
+  await writeFile(packagePath, updatedText);
+  return { originalText, packagePath };
+}
+
+function runPrerelease() {
+  const env = {
+    ...process.env,
+    npm_config_cache:
+      process.env.npm_config_cache ?? path.join(os.tmpdir(), 'eslint-config-npm-cache')
+  };
+
+  const result = spawnSync('yarn', ['prerelease'], {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit'
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`yarn prerelease exited with code ${result.status ?? 1}.`);
+  }
+}
+
+function printNextSteps({ notesPath, tag }) {
+  console.log('');
+  console.log(`Prepared ${tag}.`);
+  console.log('');
+  console.log('Next steps:');
+  console.log('1. Push the release commit:');
+  console.log('   git push origin HEAD');
+  console.log('2. Push the release tag:');
+  console.log(`   git push origin ${tag}`);
+  console.log('3. Create the GitHub Release with the generated notes:');
+  console.log(`   gh release create ${tag} --notes-file ${notesPath}`);
+  console.log('');
+  console.log('Rollback before pushing:');
+  console.log(`   git tag -d ${tag}`);
+  console.log('   git reset --soft HEAD~1');
+}
+
+async function main() {
+  const version = normalizeVersionInput(process.argv[2]);
+  if (!isReleaseVersion(version)) {
+    throw new Error(
+      `Release version '${version}' is invalid. Use MAJOR.MINOR.PATCH with optional prerelease, e.g. 1.2.3 or 1.2.3-rc.1.`
+    );
+  }
+
+  const tag = `v${version}`;
+  parseReleaseTag(tag);
+  let committed = false;
+
+  assertCleanWorkingTree();
+  assertGitIdentityConfigured();
+  assertTagDoesNotExist(tag);
+
+  const { originalText, packagePath } = await updatePackageVersion(version);
+
+  try {
+    runPrerelease();
+
+    const notesDir = '.release-notes';
+    const notesPath = `${notesDir}/${tag}.md`;
+    await mkdir(path.join(repoRoot, notesDir), { recursive: true });
+    await generateReleaseNotes({ cwd: repoRoot, outputPath: notesPath, version });
+
+    runGitInherited(['add', 'package.json']);
+    runGitInherited(['commit', '-m', `Release ${tag}`]);
+    committed = true;
+    runGitInherited(['tag', '-a', tag, '-m', `Release ${tag}`]);
+
+    printNextSteps({ notesPath, tag });
+  } catch (error) {
+    if (!committed) {
+      await writeFile(packagePath, originalText);
+    }
+    throw error;
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -48,10 +48,18 @@ function assertGitIdentityConfigured() {
   }
 }
 
-function assertTagDoesNotExist(tag) {
-  const existing = runGit(['tag', '--list', tag]);
-  if (existing) {
+export function assertTagDoesNotExist(tag, { cwd = repoRoot } = {}) {
+  const localExisting = runGit(['tag', '--list', tag], { cwd });
+  if (localExisting) {
     throw new Error(`Tag ${tag} already exists.`);
+  }
+
+  const remoteExisting = runOptionalGit(
+    ['ls-remote', '--tags', '--refs', 'origin', `refs/tags/${tag}`],
+    { cwd }
+  );
+  if (remoteExisting) {
+    throw new Error(`Tag ${tag} already exists on origin.`);
   }
 }
 

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -54,10 +54,16 @@ export function assertTagDoesNotExist(tag, { cwd = repoRoot } = {}) {
     throw new Error(`Tag ${tag} already exists.`);
   }
 
-  const remoteExisting = runOptionalGit(
-    ['ls-remote', '--tags', '--refs', 'origin', `refs/tags/${tag}`],
-    { cwd }
-  );
+  const remoteExisting = (() => {
+    try {
+      return runGit(['ls-remote', '--tags', '--refs', 'origin', `refs/tags/${tag}`], {
+        cwd
+      });
+    } catch {
+      throw new Error('Unable to verify tags on origin. Check remote access and try again.');
+    }
+  })();
+
   if (remoteExisting) {
     throw new Error(`Tag ${tag} already exists on origin.`);
   }

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -2,7 +2,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { generateReleaseNotes } from './notes.mjs';
 import { isReleaseVersion, normalizeVersionInput, parseReleaseTag } from './core.mjs';
 
@@ -17,9 +17,9 @@ function runGit(args, { cwd = repoRoot } = {}) {
   }).trim();
 }
 
-function runOptionalGit(args) {
+function runOptionalGit(args, options) {
   try {
-    return runGit(args);
+    return runGit(args, options);
   } catch {
     return '';
   }
@@ -65,6 +65,20 @@ async function updatePackageVersion(version) {
   return { originalText, packagePath };
 }
 
+export async function restorePackageJson({
+  cwd = repoRoot,
+  originalText,
+  packagePath = path.join(cwd, 'package.json')
+}) {
+  const absolutePackagePath = path.isAbsolute(packagePath)
+    ? packagePath
+    : path.join(cwd, packagePath);
+  const packagePathspec = path.relative(cwd, absolutePackagePath) || path.basename(packagePath);
+
+  runOptionalGit(['reset', '--', packagePathspec], { cwd });
+  await writeFile(absolutePackagePath, originalText);
+}
+
 function runPrerelease() {
   const env = {
     ...process.env,
@@ -104,8 +118,8 @@ function printNextSteps({ notesPath, tag }) {
   console.log('   git reset --soft HEAD~1');
 }
 
-async function main() {
-  const version = normalizeVersionInput(process.argv[2]);
+async function main(argv = process.argv.slice(2)) {
+  const version = normalizeVersionInput(argv[0]);
   if (!isReleaseVersion(version)) {
     throw new Error(
       `Release version '${version}' is invalid. Use MAJOR.MINOR.PATCH with optional prerelease, e.g. 1.2.3 or 1.2.3-rc.1.`
@@ -138,15 +152,17 @@ async function main() {
     printNextSteps({ notesPath, tag });
   } catch (error) {
     if (!committed) {
-      await writeFile(packagePath, originalText);
+      await restorePackageJson({ originalText, packagePath });
     }
     throw error;
   }
 }
 
-try {
-  await main();
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -93,6 +93,16 @@ export async function restorePackageJson({
   await writeFile(absolutePackagePath, originalText);
 }
 
+export function rollbackReleaseCommitIfTagMissing(tag, { cwd = repoRoot } = {}) {
+  const existingTag = runGit(['tag', '--list', tag], { cwd });
+  if (existingTag) {
+    return false;
+  }
+
+  runGit(['reset', '--soft', 'HEAD~1'], { cwd });
+  return true;
+}
+
 function runPrerelease() {
   const env = {
     ...process.env,
@@ -165,7 +175,7 @@ async function main(argv = process.argv.slice(2)) {
 
     printNextSteps({ notesPath, tag });
   } catch (error) {
-    if (!committed) {
+    if (!committed || rollbackReleaseCommitIfTagMissing(tag)) {
       await restorePackageJson({ originalText, packagePath });
     }
     throw error;

--- a/scripts/release/prepare.test.mjs
+++ b/scripts/release/prepare.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { restorePackageJson } from './prepare.mjs';
+import { assertTagDoesNotExist, restorePackageJson } from './prepare.mjs';
 
 function git(cwd, args) {
   return execFileSync('git', args, {
@@ -40,6 +40,57 @@ test('restorePackageJson unstages and restores package.json', async () => {
 
     assert.equal(await readFile(packagePath, 'utf8'), originalText);
     assert.equal(git(tempDir, ['status', '--porcelain']), '');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('assertTagDoesNotExist rejects existing local tags', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-local-tag-'));
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(path.join(tempDir, 'package.json'), '{}\n');
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.2.3']);
+
+    assert.throws(
+      () => assertTagDoesNotExist('v1.2.3', { cwd: tempDir }),
+      /Tag v1\.2\.3 already exists\./u
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('assertTagDoesNotExist rejects existing origin tags', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-remote-tag-'));
+  const remoteDir = path.join(tempDir, 'origin.git');
+  const workDir = path.join(tempDir, 'work');
+
+  try {
+    await mkdir(workDir);
+    git(tempDir, ['init', '--bare', remoteDir]);
+    git(workDir, ['init']);
+    git(workDir, ['config', 'user.email', 'test@example.com']);
+    git(workDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(path.join(workDir, 'package.json'), '{}\n');
+    git(workDir, ['add', 'package.json']);
+    git(workDir, ['commit', '-m', 'Initial release']);
+    git(workDir, ['tag', 'v1.2.3']);
+    git(workDir, ['remote', 'add', 'origin', remoteDir]);
+    git(workDir, ['push', 'origin', 'v1.2.3']);
+    git(workDir, ['tag', '-d', 'v1.2.3']);
+
+    assert.throws(
+      () => assertTagDoesNotExist('v1.2.3', { cwd: workDir }),
+      /Tag v1\.2\.3 already exists on origin\./u
+    );
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }

--- a/scripts/release/prepare.test.mjs
+++ b/scripts/release/prepare.test.mjs
@@ -95,3 +95,18 @@ test('assertTagDoesNotExist rejects existing origin tags', async () => {
     await rm(tempDir, { force: true, recursive: true });
   }
 });
+
+test('assertTagDoesNotExist rejects unverifiable origin tags', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-missing-origin-'));
+
+  try {
+    git(tempDir, ['init']);
+
+    assert.throws(
+      () => assertTagDoesNotExist('v1.2.3', { cwd: tempDir }),
+      /Unable to verify tags on origin\. Check remote access and try again\./u
+    );
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});

--- a/scripts/release/prepare.test.mjs
+++ b/scripts/release/prepare.test.mjs
@@ -4,7 +4,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { assertTagDoesNotExist, restorePackageJson } from './prepare.mjs';
+import {
+  assertTagDoesNotExist,
+  restorePackageJson,
+  rollbackReleaseCommitIfTagMissing
+} from './prepare.mjs';
 
 function git(cwd, args) {
   return execFileSync('git', args, {
@@ -39,6 +43,71 @@ test('restorePackageJson unstages and restores package.json', async () => {
     });
 
     assert.equal(await readFile(packagePath, 'utf8'), originalText);
+    assert.equal(git(tempDir, ['status', '--porcelain']), '');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('rollbackReleaseCommitIfTagMissing soft-resets the release commit before package restore', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-tag-failure-'));
+  const packagePath = path.join(tempDir, 'package.json');
+  const originalText = `${JSON.stringify({ name: 'test-package', version: '1.0.0' }, null, 2)}\n`;
+  const bumpedText = `${JSON.stringify({ name: 'test-package', version: '1.1.0' }, null, 2)}\n`;
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(packagePath, originalText);
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    const originalHead = git(tempDir, ['rev-parse', 'HEAD']);
+
+    await writeFile(packagePath, bumpedText);
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Release v1.1.0']);
+
+    assert.equal(rollbackReleaseCommitIfTagMissing('v1.1.0', { cwd: tempDir }), true);
+    assert.equal(git(tempDir, ['rev-parse', 'HEAD']), originalHead);
+
+    await restorePackageJson({
+      cwd: tempDir,
+      originalText,
+      packagePath
+    });
+
+    assert.equal(await readFile(packagePath, 'utf8'), originalText);
+    assert.equal(git(tempDir, ['status', '--porcelain']), '');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('rollbackReleaseCommitIfTagMissing keeps the release commit when the tag exists', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-tag-present-'));
+  const packagePath = path.join(tempDir, 'package.json');
+  const originalText = `${JSON.stringify({ name: 'test-package', version: '1.0.0' }, null, 2)}\n`;
+  const bumpedText = `${JSON.stringify({ name: 'test-package', version: '1.1.0' }, null, 2)}\n`;
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(packagePath, originalText);
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+
+    await writeFile(packagePath, bumpedText);
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Release v1.1.0']);
+    const releaseHead = git(tempDir, ['rev-parse', 'HEAD']);
+    git(tempDir, ['tag', 'v1.1.0']);
+
+    assert.equal(rollbackReleaseCommitIfTagMissing('v1.1.0', { cwd: tempDir }), false);
+    assert.equal(git(tempDir, ['rev-parse', 'HEAD']), releaseHead);
     assert.equal(git(tempDir, ['status', '--porcelain']), '');
   } finally {
     await rm(tempDir, { force: true, recursive: true });

--- a/scripts/release/prepare.test.mjs
+++ b/scripts/release/prepare.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { restorePackageJson } from './prepare.mjs';
+
+function git(cwd, args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+test('restorePackageJson unstages and restores package.json', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-'));
+  const packagePath = path.join(tempDir, 'package.json');
+  const originalText = `${JSON.stringify({ name: 'test-package', version: '1.0.0' }, null, 2)}\n`;
+  const bumpedText = `${JSON.stringify({ name: 'test-package', version: '1.1.0' }, null, 2)}\n`;
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(packagePath, originalText);
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+
+    await writeFile(packagePath, bumpedText);
+    git(tempDir, ['add', 'package.json']);
+
+    await restorePackageJson({
+      cwd: tempDir,
+      originalText,
+      packagePath
+    });
+
+    assert.equal(await readFile(packagePath, 'utf8'), originalText);
+    assert.equal(git(tempDir, ['status', '--porcelain']), '');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});

--- a/scripts/release/validate.mjs
+++ b/scripts/release/validate.mjs
@@ -1,0 +1,79 @@
+import {
+  appendGitHubOutput,
+  appendGitHubSummary,
+  formatValidationSummary,
+  loadPackageJson,
+  resolveReleaseContext,
+  validateReleaseFields
+} from './core.mjs';
+
+function parseArgs(argv) {
+  const args = {
+    skipReleaseNotes: false,
+    tag: null
+  };
+
+  for (const arg of argv) {
+    if (arg === '--skip-release-notes' || arg === '--skip-release-notes=true') {
+      args.skipReleaseNotes = true;
+      continue;
+    }
+
+    if (arg === '--skip-release-notes=false') {
+      args.skipReleaseNotes = false;
+      continue;
+    }
+
+    if (arg.startsWith('--tag=')) {
+      args.tag = arg.slice('--tag='.length);
+      continue;
+    }
+
+    throw new Error(`Unknown release validation argument: ${arg}`);
+  }
+
+  return args;
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const pkg = await loadPackageJson();
+  const context = await resolveReleaseContext({
+    skipReleaseNotes: args.skipReleaseNotes,
+    tag: args.tag
+  });
+
+  const result = validateReleaseFields({
+    packageName: pkg.name,
+    packageVersion: pkg.version,
+    releaseBody: context.releaseBody,
+    requireReleaseNotes: context.requireReleaseNotes,
+    tag: context.tag
+  });
+
+  const summaryResult = {
+    ...result,
+    releaseNotesStatus: context.releaseNotesStatus,
+    validationStatus: 'passed'
+  };
+
+  await appendGitHubOutput({
+    npm_access: result.npmAccess,
+    npm_dist_tag: result.npmDistTag,
+    package_name: result.packageName,
+    release_tag: result.tag,
+    release_version: result.version
+  });
+  await appendGitHubSummary(formatValidationSummary(summaryResult));
+
+  console.log(
+    `Release validation passed for ${result.packageName} ${result.tag}; npm dist-tag: ${result.npmDistTag}.`
+  );
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  await appendGitHubSummary(
+    ['## Release validation', '', `- Validation: failed`, `- Error: ${message}`, ''].join('\n')
+  );
+  console.error(`release validation failed: ${message}`);
+  process.exit(1);
+}

--- a/scripts/release/validate.mjs
+++ b/scripts/release/validate.mjs
@@ -6,14 +6,17 @@ import {
   resolveReleaseContext,
   validateReleaseFields
 } from './core.mjs';
+import { pathToFileURL } from 'node:url';
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = {
     skipReleaseNotes: false,
     tag: null
   };
 
-  for (const arg of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
     if (arg === '--skip-release-notes' || arg === '--skip-release-notes=true') {
       args.skipReleaseNotes = true;
       continue;
@@ -21,6 +24,17 @@ function parseArgs(argv) {
 
     if (arg === '--skip-release-notes=false') {
       args.skipReleaseNotes = false;
+      continue;
+    }
+
+    if (arg === '--tag') {
+      const next = argv[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--tag option requires a value, e.g. --tag v1.2.3');
+      }
+
+      args.tag = next;
+      index += 1;
       continue;
     }
 
@@ -35,8 +49,8 @@ function parseArgs(argv) {
   return args;
 }
 
-try {
-  const args = parseArgs(process.argv.slice(2));
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
   const pkg = await loadPackageJson();
   const context = await resolveReleaseContext({
     skipReleaseNotes: args.skipReleaseNotes,
@@ -69,11 +83,17 @@ try {
   console.log(
     `Release validation passed for ${result.packageName} ${result.tag}; npm dist-tag: ${result.npmDistTag}.`
   );
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  await appendGitHubSummary(
-    ['## Release validation', '', `- Validation: failed`, `- Error: ${message}`, ''].join('\n')
-  );
-  console.error(`release validation failed: ${message}`);
-  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await appendGitHubSummary(
+      ['## Release validation', '', `- Validation: failed`, `- Error: ${message}`, ''].join('\n')
+    );
+    console.error(`release validation failed: ${message}`);
+    process.exit(1);
+  }
 }

--- a/scripts/release/validate.mjs
+++ b/scripts/release/validate.mjs
@@ -39,7 +39,12 @@ export function parseArgs(argv) {
     }
 
     if (arg.startsWith('--tag=')) {
-      args.tag = arg.slice('--tag='.length);
+      const value = arg.slice('--tag='.length);
+      if (!value) {
+        throw new Error('--tag option requires a value, e.g. --tag=v1.2.3');
+      }
+
+      args.tag = value;
       continue;
     }
 

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -24,7 +24,7 @@ async function findTestFiles(directory) {
   return files;
 }
 
-const testFiles = await findTestFiles(process.cwd());
+const testFiles = (await findTestFiles(process.cwd())).sort();
 
 if (testFiles.length === 0) {
   console.log('✅ Tests skipped: no matching *.test.mjs or *.spec.mjs files found.');

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -27,7 +27,7 @@ async function findTestFiles(directory) {
 const testFiles = await findTestFiles(process.cwd());
 
 if (testFiles.length === 0) {
-  console.log('✅ Tests skipped: no test runner configured yet.');
+  console.log('✅ Tests skipped: no matching *.test.mjs or *.spec.mjs files found.');
   process.exit(0);
 }
 

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,2 +1,43 @@
-console.log('✅ Tests skipped: no test runner configured yet.');
-process.exit(0);
+import { spawnSync } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const ignoredDirectories = new Set(['.git', '.yarn', 'node_modules']);
+
+async function findTestFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        files.push(...(await findTestFiles(path.join(directory, entry.name))));
+      }
+      continue;
+    }
+
+    if (entry.isFile() && /\.(test|spec)\.mjs$/u.test(entry.name)) {
+      files.push(path.join(directory, entry.name));
+    }
+  }
+
+  return files;
+}
+
+const testFiles = await findTestFiles(process.cwd());
+
+if (testFiles.length === 0) {
+  console.log('✅ Tests skipped: no test runner configured yet.');
+  process.exit(0);
+}
+
+const result = spawnSync(process.execPath, ['--test', ...testFiles], {
+  stdio: 'inherit'
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- Replace inline release validation with tested Node helpers and a `release:validate` script.
- Add `release:notes` and `release:prepare` to support local release prep, tag creation, and generated notes.
- Update the release workflow to validate metadata, publish prereleases to `next`, and show a clearer publish summary.
- Harden prerelease packing against local npm cache issues and make `scripts/test.mjs` run Node test files automatically.
- Document the new release flow and keep generated release notes out of source control.

## Testing
- Added `node:test` coverage for tag parsing, release validation, dist-tag selection, and release note generation.
- Verified the repo gates locally: lint, typecheck, tests, and prerelease checks passed.

## Summary by Sourcery

Refine the release process with scripted validation, note generation, and clearer publish behavior for npm releases.

New Features:
- Add Node-based release helpers and yarn scripts for release validation, notes generation, and local release preparation.
- Automatically discover and run Node test files via the custom test runner script.

Bug Fixes:
- Stabilise prerelease packaging by isolating npm cache configuration and disabling unintended dry runs.

Enhancements:
- Update the GitHub release workflow to rely on scripted metadata validation, expose release metadata as job outputs, and provide a readable publish target summary with dry-run and final commands.
- Adjust publish steps to respect computed npm access and dist-tags, publishing prereleases to the `next` tag and stable releases to `latest`.
- Tweak package repository metadata to use the npm-preferred Git+HTTPS URL format.

Documentation:
- Rewrite the release documentation to describe the new local release preparation flow, generated release notes, prerelease handling, and rollback instructions.

Tests:
- Add node:test coverage for release tag parsing, release validation, dist-tag selection, and release note generation utilities.