### PR TITLE
Add release version recommendation to yarn release:prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,15 @@ Publishing is **GitHub Release-driven**.
 
 ### 🧭 Release flow
 
-1. Prepare the local release commit, tag, and notes:
+1. Ask the helper for the recommended next version:
+
+   ```bash
+   yarn release:prepare
+   ```
+
+   The helper inspects commits since the latest release tag, recommends the next version, and prints patch, minor, major, and release-candidate alternatives. It does not change files until you pass a version explicitly.
+
+2. Prepare the local release commit, tag, and notes:
 
    ```bash
    yarn release:prepare 1.2.3
@@ -132,14 +140,14 @@ Publishing is **GitHub Release-driven**.
 
    Use prerelease versions such as `1.2.3-rc.1` when needed. The helper updates `package.json`, runs `yarn prerelease`, creates `Release vX.Y.Z`, creates an annotated `vX.Y.Z` tag, and writes notes to `.release-notes/vX.Y.Z.md`.
 
-2. Push the release commit and tag:
+3. Push the release commit and tag:
 
    ```bash
    git push origin HEAD
    git push origin v1.2.3
    ```
 
-3. Create the GitHub Release using the generated notes:
+4. Create the GitHub Release using the generated notes:
 
    ```bash
    gh release create v1.2.3 --notes-file .release-notes/v1.2.3.md
@@ -147,7 +155,7 @@ Publishing is **GitHub Release-driven**.
 
    You can also create the release in the GitHub UI, but the release body must contain human-readable notes.
 
-4. GitHub Actions runs `.github/workflows/release.yml`, validates the tag, release notes, package version, package contents, and import smoke test by default, then publishes to npm. For manual runs, `skip_release_notes=true` bypasses only the release-notes check.
+5. GitHub Actions runs `.github/workflows/release.yml`, validates the tag, release notes, package version, package contents, and import smoke test by default, then publishes to npm. For manual runs, `skip_release_notes=true` bypasses only the release-notes check.
 
 Stable versions publish to npm’s `latest` dist-tag. Prerelease versions publish to `next`, so release candidates do not replace the default install target.
 

--- a/scripts/release/core.mjs
+++ b/scripts/release/core.mjs
@@ -1,6 +1,8 @@
 import { appendFile, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+const numericIdentifierPattern = /^[0-9]+$/u;
+
 export const releaseTagPattern =
   /^v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/;
 
@@ -36,6 +38,152 @@ export function parseReleaseTag(tag) {
     tag: tag.trim(),
     version: match.groups.version
   };
+}
+
+function compareNumbers(left, right) {
+  return Math.sign(left - right);
+}
+
+function compareAscii(left, right) {
+  const length = Math.min(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const characterComparison = compareNumbers(left.charCodeAt(index), right.charCodeAt(index));
+
+    if (characterComparison !== 0) {
+      return characterComparison;
+    }
+  }
+
+  return compareNumbers(left.length, right.length);
+}
+
+export function parseComparableReleaseVersion(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error('Release version is required.');
+  }
+
+  const trimmed = value.trim();
+  const normalizedVersion = trimmed.startsWith('v') ? parseReleaseTag(trimmed).version : trimmed;
+
+  if (!isReleaseVersion(normalizedVersion)) {
+    throw new Error(`Release version '${value}' is invalid.`);
+  }
+
+  const prereleaseStartIndex = normalizedVersion.indexOf('-');
+  const coreVersion =
+    prereleaseStartIndex === -1
+      ? normalizedVersion
+      : normalizedVersion.slice(0, prereleaseStartIndex);
+  const prereleaseVersion =
+    prereleaseStartIndex === -1 ? '' : normalizedVersion.slice(prereleaseStartIndex + 1);
+  const [major, minor, patch] = coreVersion.split('.').map(Number);
+
+  return {
+    coreVersion,
+    major,
+    minor,
+    patch,
+    prerelease: prereleaseVersion ? prereleaseVersion.split('.') : [],
+    version: normalizedVersion
+  };
+}
+
+export function parseComparableReleaseTag(tag) {
+  const parsedTag = parseReleaseTag(tag);
+  return {
+    ...parseComparableReleaseVersion(parsedTag.version),
+    tag: parsedTag.tag
+  };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  const leftIsNumeric = numericIdentifierPattern.test(left);
+  const rightIsNumeric = numericIdentifierPattern.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return compareNumbers(Number(left), Number(right));
+  }
+
+  if (leftIsNumeric) {
+    return -1;
+  }
+
+  if (rightIsNumeric) {
+    return 1;
+  }
+
+  return compareAscii(left, right);
+}
+
+export function compareParsedReleaseVersions(left, right) {
+  const coreComparison =
+    compareNumbers(left.major, right.major) ||
+    compareNumbers(left.minor, right.minor) ||
+    compareNumbers(left.patch, right.patch);
+
+  if (coreComparison !== 0) {
+    return coreComparison;
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const identifierComparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
+    if (identifierComparison !== 0) {
+      return identifierComparison;
+    }
+  }
+
+  return 0;
+}
+
+export function isStableReleaseVersion(parsedVersion) {
+  return parsedVersion.prerelease.length === 0;
+}
+
+export function getSemverReleaseTags({ cwd = process.cwd(), run } = {}) {
+  if (typeof run !== 'function') {
+    throw new Error('A git runner is required to list release tags.');
+  }
+
+  const output = run(['tag', '--list', 'v*'], cwd);
+  return output
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => {
+      try {
+        return parseComparableReleaseTag(tag);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .sort((left, right) => compareParsedReleaseVersions(right, left))
+    .map(({ tag }) => tag);
 }
 
 export function getNpmDistTagForVersion(version) {

--- a/scripts/release/core.test.mjs
+++ b/scripts/release/core.test.mjs
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import {
+  getSemverReleaseTags,
   getNpmDistTagForVersion,
   parseReleaseTag,
   resolveReleaseContext,
@@ -57,6 +58,23 @@ test('validateReleaseFields rejects empty release notes when required', () => {
 test('getNpmDistTagForVersion maps stable releases to latest and prereleases to next', () => {
   assert.equal(getNpmDistTagForVersion('1.2.3'), 'latest');
   assert.equal(getNpmDistTagForVersion('1.2.3-rc.1'), 'next');
+});
+
+test('getSemverReleaseTags filters and sorts release tags by semver precedence', () => {
+  assert.deepEqual(
+    getSemverReleaseTags({
+      run: () =>
+        [
+          'v1.0.0',
+          'not-a-release',
+          'v1.0.2-rc.1',
+          'v1.0.10',
+          'v1.0.2',
+          'v1.0.2-rc.2'
+        ].join('\n')
+    }),
+    ['v1.0.10', 'v1.0.2', 'v1.0.2-rc.2', 'v1.0.2-rc.1', 'v1.0.0']
+  );
 });
 
 test('parseArgs accepts both release validation tag forms', () => {

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -2,7 +2,14 @@ import { execFileSync } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { loadPackageJson, normalizeVersionInput, parseReleaseTag } from './core.mjs';
+import {
+  compareParsedReleaseVersions,
+  getSemverReleaseTags,
+  isStableReleaseVersion,
+  loadPackageJson,
+  normalizeVersionInput,
+  parseComparableReleaseTag
+} from './core.mjs';
 
 function runGit(args, cwd) {
   return execFileSync('git', args, {
@@ -12,136 +19,18 @@ function runGit(args, cwd) {
   }).trim();
 }
 
-const numericIdentifierPattern = /^[0-9]+$/u;
-
-function compareNumbers(left, right) {
-  return Math.sign(left - right);
-}
-
-function compareAscii(left, right) {
-  const length = Math.min(left.length, right.length);
-
-  for (let index = 0; index < length; index += 1) {
-    const characterComparison = compareNumbers(left.charCodeAt(index), right.charCodeAt(index));
-
-    if (characterComparison !== 0) {
-      return characterComparison;
-    }
-  }
-
-  return compareNumbers(left.length, right.length);
-}
-
-function parseComparableTag(tag) {
-  const { version } = parseReleaseTag(tag);
-  const prereleaseStartIndex = version.indexOf('-');
-  const coreVersion =
-    prereleaseStartIndex === -1 ? version : version.slice(0, prereleaseStartIndex);
-  const prereleaseVersion =
-    prereleaseStartIndex === -1 ? '' : version.slice(prereleaseStartIndex + 1);
-  const [major, minor, patch] = coreVersion.split('.').map(Number);
-
-  return {
-    major,
-    minor,
-    patch,
-    prerelease: prereleaseVersion ? prereleaseVersion.split('.') : [],
-    tag
-  };
-}
-
-function comparePrereleaseIdentifiers(left, right) {
-  const leftIsNumeric = numericIdentifierPattern.test(left);
-  const rightIsNumeric = numericIdentifierPattern.test(right);
-
-  if (leftIsNumeric && rightIsNumeric) {
-    return compareNumbers(Number(left), Number(right));
-  }
-
-  if (leftIsNumeric) {
-    return -1;
-  }
-
-  if (rightIsNumeric) {
-    return 1;
-  }
-
-  return compareAscii(left, right);
-}
-
-function compareParsedTags(left, right) {
-  const coreComparison =
-    compareNumbers(left.major, right.major) ||
-    compareNumbers(left.minor, right.minor) ||
-    compareNumbers(left.patch, right.patch);
-
-  if (coreComparison !== 0) {
-    return coreComparison;
-  }
-
-  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
-    return 0;
-  }
-
-  if (left.prerelease.length === 0) {
-    return 1;
-  }
-
-  if (right.prerelease.length === 0) {
-    return -1;
-  }
-
-  const length = Math.max(left.prerelease.length, right.prerelease.length);
-  for (let index = 0; index < length; index += 1) {
-    const leftIdentifier = left.prerelease[index];
-    const rightIdentifier = right.prerelease[index];
-
-    if (leftIdentifier === undefined) {
-      return -1;
-    }
-
-    if (rightIdentifier === undefined) {
-      return 1;
-    }
-
-    const identifierComparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
-    if (identifierComparison !== 0) {
-      return identifierComparison;
-    }
-  }
-
-  return 0;
-}
-
-function isStableTag(parsedTag) {
-  return parsedTag.prerelease.length === 0;
-}
-
 export function getSemverTags({ cwd = process.cwd(), run = runGit } = {}) {
-  const output = run(['tag', '--list', 'v*'], cwd);
-  return output
-    .split('\n')
-    .map((tag) => tag.trim())
-    .filter(Boolean)
-    .filter((tag) => {
-      try {
-        parseReleaseTag(tag);
-        return true;
-      } catch {
-        return false;
-      }
-    })
-    .sort((left, right) => compareParsedTags(parseComparableTag(right), parseComparableTag(left)));
+  return getSemverReleaseTags({ cwd, run });
 }
 
 export function getPreviousReleaseTag({ currentTag, cwd = process.cwd(), run = runGit } = {}) {
-  const current = parseComparableTag(currentTag);
+  const current = parseComparableReleaseTag(currentTag);
   const candidates = getSemverTags({ cwd, run })
     .filter((tag) => tag !== currentTag)
-    .map((tag) => parseComparableTag(tag))
-    .filter((candidate) => compareParsedTags(candidate, current) < 0)
-    .filter((candidate) => !isStableTag(current) || isStableTag(candidate))
-    .sort((left, right) => compareParsedTags(right, left));
+    .map((tag) => parseComparableReleaseTag(tag))
+    .filter((candidate) => compareParsedReleaseVersions(candidate, current) < 0)
+    .filter((candidate) => !isStableReleaseVersion(current) || isStableReleaseVersion(candidate))
+    .sort((left, right) => compareParsedReleaseVersions(right, left));
 
   return candidates[0]?.tag ?? null;
 }

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -5,6 +5,10 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { generateReleaseNotes } from './notes.mjs';
 import { isReleaseVersion, normalizeVersionInput, parseReleaseTag } from './core.mjs';
+import {
+  formatReleaseVersionRecommendation,
+  getReleaseVersionRecommendation
+} from './recommend.mjs';
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptsDir, '../..');
@@ -25,23 +29,23 @@ function runOptionalGit(args, options) {
   }
 }
 
-function runGitInherited(args) {
+function runGitInherited(args, { cwd = repoRoot } = {}) {
   execFileSync('git', args, {
-    cwd: repoRoot,
+    cwd,
     stdio: 'inherit'
   });
 }
 
-function assertCleanWorkingTree() {
-  const status = runGit(['status', '--porcelain']);
+function assertCleanWorkingTree({ cwd = repoRoot } = {}) {
+  const status = runGit(['status', '--porcelain'], { cwd });
   if (status) {
     throw new Error('Working tree must be clean before preparing a release.');
   }
 }
 
-function assertGitIdentityConfigured() {
-  const name = runOptionalGit(['config', '--get', 'user.name']);
-  const email = runOptionalGit(['config', '--get', 'user.email']);
+function assertGitIdentityConfigured({ cwd = repoRoot } = {}) {
+  const name = runOptionalGit(['config', '--get', 'user.name'], { cwd });
+  const email = runOptionalGit(['config', '--get', 'user.email'], { cwd });
 
   if (!name || !email) {
     throw new Error('Git user.name and user.email must be configured before creating a release commit.');
@@ -69,8 +73,8 @@ export function assertTagDoesNotExist(tag, { cwd = repoRoot } = {}) {
   }
 }
 
-async function updatePackageVersion(version) {
-  const packagePath = path.join(repoRoot, 'package.json');
+async function updatePackageVersion(version, { cwd = repoRoot } = {}) {
+  const packagePath = path.join(cwd, 'package.json');
   const originalText = await readFile(packagePath, 'utf8');
   const pkg = JSON.parse(originalText);
   pkg.version = version;
@@ -103,7 +107,7 @@ export function rollbackReleaseCommitIfTagMissing(tag, { cwd = repoRoot } = {}) 
   return true;
 }
 
-function runPrerelease() {
+function runPrerelease({ cwd = repoRoot } = {}) {
   const env = {
     ...process.env,
     npm_config_cache:
@@ -111,7 +115,7 @@ function runPrerelease() {
   };
 
   const result = spawnSync('yarn', ['prerelease'], {
-    cwd: repoRoot,
+    cwd,
     env,
     stdio: 'inherit'
   });
@@ -125,24 +129,30 @@ function runPrerelease() {
   }
 }
 
-function printNextSteps({ notesPath, tag }) {
-  console.log('');
-  console.log(`Prepared ${tag}.`);
-  console.log('');
-  console.log('Next steps:');
-  console.log('1. Push the release commit:');
-  console.log('   git push origin HEAD');
-  console.log('2. Push the release tag:');
-  console.log(`   git push origin ${tag}`);
-  console.log('3. Create the GitHub Release with the generated notes:');
-  console.log(`   gh release create ${tag} --notes-file ${notesPath}`);
-  console.log('');
-  console.log('Rollback before pushing:');
-  console.log(`   git tag -d ${tag}`);
-  console.log('   git reset --soft HEAD~1');
+function printNextSteps({ log = console.log, notesPath, tag }) {
+  log('');
+  log(`Prepared ${tag}.`);
+  log('');
+  log('Next steps:');
+  log('1. Push the release commit:');
+  log('   git push origin HEAD');
+  log('2. Push the release tag:');
+  log(`   git push origin ${tag}`);
+  log('3. Create the GitHub Release with the generated notes:');
+  log(`   gh release create ${tag} --notes-file ${notesPath}`);
+  log('');
+  log('Rollback before pushing:');
+  log(`   git tag -d ${tag}`);
+  log('   git reset --soft HEAD~1');
 }
 
-async function main(argv = process.argv.slice(2)) {
+export async function main(argv = process.argv.slice(2), { cwd = repoRoot, log = console.log } = {}) {
+  if (typeof argv[0] !== 'string' || !argv[0].trim()) {
+    const recommendation = await getReleaseVersionRecommendation({ cwd });
+    log(formatReleaseVersionRecommendation(recommendation));
+    return;
+  }
+
   const version = normalizeVersionInput(argv[0]);
   if (!isReleaseVersion(version)) {
     throw new Error(
@@ -154,29 +164,29 @@ async function main(argv = process.argv.slice(2)) {
   parseReleaseTag(tag);
   let committed = false;
 
-  assertCleanWorkingTree();
-  assertGitIdentityConfigured();
-  assertTagDoesNotExist(tag);
+  assertCleanWorkingTree({ cwd });
+  assertGitIdentityConfigured({ cwd });
+  assertTagDoesNotExist(tag, { cwd });
 
-  const { originalText, packagePath } = await updatePackageVersion(version);
+  const { originalText, packagePath } = await updatePackageVersion(version, { cwd });
 
   try {
-    runPrerelease();
+    runPrerelease({ cwd });
 
     const notesDir = '.release-notes';
     const notesPath = `${notesDir}/${tag}.md`;
-    await mkdir(path.join(repoRoot, notesDir), { recursive: true });
-    await generateReleaseNotes({ cwd: repoRoot, outputPath: notesPath, version });
+    await mkdir(path.join(cwd, notesDir), { recursive: true });
+    await generateReleaseNotes({ cwd, outputPath: notesPath, version });
 
-    runGitInherited(['add', 'package.json']);
-    runGitInherited(['commit', '-m', `Release ${tag}`]);
+    runGitInherited(['add', 'package.json'], { cwd });
+    runGitInherited(['commit', '-m', `Release ${tag}`], { cwd });
     committed = true;
-    runGitInherited(['tag', '-a', tag, '-m', `Release ${tag}`]);
+    runGitInherited(['tag', '-a', tag, '-m', `Release ${tag}`], { cwd });
 
-    printNextSteps({ notesPath, tag });
+    printNextSteps({ log, notesPath, tag });
   } catch (error) {
-    if (!committed || rollbackReleaseCommitIfTagMissing(tag)) {
-      await restorePackageJson({ originalText, packagePath });
+    if (!committed || rollbackReleaseCommitIfTagMissing(tag, { cwd })) {
+      await restorePackageJson({ cwd, originalText, packagePath });
     }
     throw error;
   }

--- a/scripts/release/prepare.test.mjs
+++ b/scripts/release/prepare.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import test from 'node:test';
 import {
   assertTagDoesNotExist,
+  main,
   restorePackageJson,
   rollbackReleaseCommitIfTagMissing
 } from './prepare.mjs';
@@ -178,4 +179,57 @@ test('assertTagDoesNotExist rejects unverifiable origin tags', async () => {
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }
+});
+
+test('main prints a next-version recommendation before clean-tree checks when no version is supplied', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-prepare-recommend-'));
+  const packagePath = path.join(tempDir, 'package.json');
+  const originalText = `${JSON.stringify(
+    {
+      name: '@smolpack/eslint-config',
+      version: '1.0.2'
+    },
+    null,
+    2
+  )}\n`;
+  const output = [];
+
+  try {
+    git(tempDir, ['init']);
+    git(tempDir, ['config', 'user.email', 'test@example.com']);
+    git(tempDir, ['config', 'user.name', 'Release Test']);
+
+    await writeFile(packagePath, originalText);
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Initial release']);
+    git(tempDir, ['tag', 'v1.0.2']);
+
+    await writeFile(path.join(tempDir, 'dirty.txt'), 'dirty\n');
+
+    await main([], {
+      cwd: tempDir,
+      log(line = '') {
+        output.push(line);
+      }
+    });
+
+    const message = output.join('\n');
+    assert.match(message, /Recommended next version: 1\.0\.3/u);
+    assert.match(message, /yarn release:prepare 1\.0\.3/u);
+    assert.equal(await readFile(packagePath, 'utf8'), originalText);
+    assert.match(git(tempDir, ['status', '--porcelain']), /\?\? dirty\.txt/u);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('main still rejects invalid explicit release versions', async () => {
+  await assert.rejects(
+    () =>
+      main(['not-a-version'], {
+        cwd: os.tmpdir(),
+        log() {}
+      }),
+    /Release version 'not-a-version' is invalid/u
+  );
 });

--- a/scripts/release/recommend.mjs
+++ b/scripts/release/recommend.mjs
@@ -1,7 +1,14 @@
 import { execFileSync } from 'node:child_process';
-import { loadPackageJson, parseReleaseTag } from './core.mjs';
+import {
+  compareParsedReleaseVersions,
+  getSemverReleaseTags as getCoreSemverReleaseTags,
+  isStableReleaseVersion,
+  loadPackageJson,
+  parseComparableReleaseTag,
+  parseComparableReleaseVersion
+} from './core.mjs';
 
-const numericIdentifierPattern = /^[0-9]+$/u;
+const rcNumberPattern = /^[0-9]+$/u;
 const breakingChangeFooterPattern = /^BREAKING[ -]CHANGE:/mu;
 const conventionalBreakingSubjectPattern = /^[a-z][a-z0-9-]*(?:\([^)]+\))?!:/iu;
 const conventionalFeatureSubjectPattern = /^feat(?:\([^)]+\))?!?:/u;
@@ -14,123 +21,12 @@ function runGit(args, cwd) {
   }).trim();
 }
 
-function compareNumbers(left, right) {
-  return Math.sign(left - right);
-}
-
-function compareAscii(left, right) {
-  const length = Math.min(left.length, right.length);
-
-  for (let index = 0; index < length; index += 1) {
-    const characterComparison = compareNumbers(left.charCodeAt(index), right.charCodeAt(index));
-
-    if (characterComparison !== 0) {
-      return characterComparison;
-    }
-  }
-
-  return compareNumbers(left.length, right.length);
-}
-
-function parseComparableVersion(version) {
-  const normalizedVersion = parseReleaseTag(version.startsWith('v') ? version : `v${version}`)
-    .version;
-  const prereleaseStartIndex = normalizedVersion.indexOf('-');
-  const coreVersion =
-    prereleaseStartIndex === -1
-      ? normalizedVersion
-      : normalizedVersion.slice(0, prereleaseStartIndex);
-  const prereleaseVersion =
-    prereleaseStartIndex === -1 ? '' : normalizedVersion.slice(prereleaseStartIndex + 1);
-  const [major, minor, patch] = coreVersion.split('.').map(Number);
-
-  if (![major, minor, patch].every(Number.isInteger)) {
-    throw new Error(`Release version '${version}' is invalid.`);
-  }
-
-  return {
-    coreVersion,
-    major,
-    minor,
-    patch,
-    prerelease: prereleaseVersion ? prereleaseVersion.split('.') : [],
-    version: normalizedVersion
-  };
-}
-
-function comparePrereleaseIdentifiers(left, right) {
-  const leftIsNumeric = numericIdentifierPattern.test(left);
-  const rightIsNumeric = numericIdentifierPattern.test(right);
-
-  if (leftIsNumeric && rightIsNumeric) {
-    return compareNumbers(Number(left), Number(right));
-  }
-
-  if (leftIsNumeric) {
-    return -1;
-  }
-
-  if (rightIsNumeric) {
-    return 1;
-  }
-
-  return compareAscii(left, right);
-}
-
-function compareParsedVersions(left, right) {
-  const coreComparison =
-    compareNumbers(left.major, right.major) ||
-    compareNumbers(left.minor, right.minor) ||
-    compareNumbers(left.patch, right.patch);
-
-  if (coreComparison !== 0) {
-    return coreComparison;
-  }
-
-  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
-    return 0;
-  }
-
-  if (left.prerelease.length === 0) {
-    return 1;
-  }
-
-  if (right.prerelease.length === 0) {
-    return -1;
-  }
-
-  const length = Math.max(left.prerelease.length, right.prerelease.length);
-  for (let index = 0; index < length; index += 1) {
-    const leftIdentifier = left.prerelease[index];
-    const rightIdentifier = right.prerelease[index];
-
-    if (leftIdentifier === undefined) {
-      return -1;
-    }
-
-    if (rightIdentifier === undefined) {
-      return 1;
-    }
-
-    const identifierComparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
-    if (identifierComparison !== 0) {
-      return identifierComparison;
-    }
-  }
-
-  return 0;
-}
-
-function isStableVersion(parsedVersion) {
-  return parsedVersion.prerelease.length === 0;
-}
-
 function formatCoreVersion({ major, minor, patch }) {
   return `${major}.${minor}.${patch}`;
 }
 
 function incrementVersion(version, bump) {
-  const parsedVersion = parseComparableVersion(version);
+  const parsedVersion = parseComparableReleaseVersion(version);
 
   if (bump === 'major') {
     return `${parsedVersion.major + 1}.0.0`;
@@ -145,29 +41,29 @@ function incrementVersion(version, bump) {
 
 function getLatestStableTag(tags) {
   return tags
-    .map((tag) => ({ parsedTag: parseComparableVersion(tag), tag }))
-    .filter(({ parsedTag }) => isStableVersion(parsedTag))
-    .sort((left, right) => compareParsedVersions(right.parsedTag, left.parsedTag))[0]?.tag;
+    .map((tag) => parseComparableReleaseTag(tag))
+    .filter((parsedTag) => isStableReleaseVersion(parsedTag))
+    .sort((left, right) => compareParsedReleaseVersions(right, left))[0]?.tag;
 }
 
 function getLatestSemverTag(tags) {
   return tags
-    .map((tag) => ({ parsedTag: parseComparableVersion(tag), tag }))
-    .sort((left, right) => compareParsedVersions(right.parsedTag, left.parsedTag))[0]?.tag;
+    .map((tag) => parseComparableReleaseTag(tag))
+    .sort((left, right) => compareParsedReleaseVersions(right, left))[0]?.tag;
 }
 
 function getBaseVersion({ latestStableTag, packageVersion }) {
-  const parsedPackageVersion = parseComparableVersion(packageVersion);
+  const parsedPackageVersion = parseComparableReleaseVersion(packageVersion);
   const packageCoreVersion = formatCoreVersion(parsedPackageVersion);
 
   if (!latestStableTag) {
     return packageCoreVersion;
   }
 
-  const latestStableVersion = parseReleaseTag(latestStableTag).version;
-  return compareParsedVersions(
-    parseComparableVersion(packageCoreVersion),
-    parseComparableVersion(latestStableVersion)
+  const latestStableVersion = parseComparableReleaseTag(latestStableTag).version;
+  return compareParsedReleaseVersions(
+    parseComparableReleaseVersion(packageCoreVersion),
+    parseComparableReleaseVersion(latestStableVersion)
   ) >= 0
     ? packageCoreVersion
     : latestStableVersion;
@@ -178,14 +74,14 @@ function getStableVersionForLatestPrerelease({ baseVersion, latestSemverTag }) {
     return null;
   }
 
-  const latestSemverVersion = parseComparableVersion(latestSemverTag);
-  if (isStableVersion(latestSemverVersion)) {
+  const latestSemverVersion = parseComparableReleaseTag(latestSemverTag);
+  if (isStableReleaseVersion(latestSemverVersion)) {
     return null;
   }
 
-  const stableCandidate = parseComparableVersion(latestSemverVersion.coreVersion);
-  const base = parseComparableVersion(baseVersion);
-  return compareParsedVersions(stableCandidate, base) >= 0 ? stableCandidate.version : null;
+  const stableCandidate = parseComparableReleaseVersion(latestSemverVersion.coreVersion);
+  const base = parseComparableReleaseVersion(baseVersion);
+  return compareParsedReleaseVersions(stableCandidate, base) >= 0 ? stableCandidate.version : null;
 }
 
 function parseReleaseCommitRecord(record) {
@@ -247,10 +143,10 @@ function deriveRecommendedBump({ commits, sourceLabel }) {
 }
 
 function getNextRcVersion({ stableVersion, tags }) {
-  const target = parseComparableVersion(stableVersion);
+  const target = parseComparableReleaseVersion(stableVersion);
   const nextRcNumber =
     tags
-      .map((tag) => parseComparableVersion(tag))
+      .map((tag) => parseComparableReleaseTag(tag))
       .filter(
         (version) =>
           version.major === target.major &&
@@ -258,7 +154,7 @@ function getNextRcVersion({ stableVersion, tags }) {
           version.patch === target.patch &&
           version.prerelease.length === 2 &&
           version.prerelease[0] === 'rc' &&
-          numericIdentifierPattern.test(version.prerelease[1])
+          rcNumberPattern.test(version.prerelease[1])
       )
       .map((version) => Number(version.prerelease[1]))
       .sort((left, right) => right - left)[0] ?? 0;
@@ -267,19 +163,7 @@ function getNextRcVersion({ stableVersion, tags }) {
 }
 
 export function getSemverReleaseTags({ cwd = process.cwd(), run = runGit } = {}) {
-  const output = run(['tag', '--list', 'v*'], cwd);
-  return output
-    .split('\n')
-    .map((tag) => tag.trim())
-    .filter(Boolean)
-    .filter((tag) => {
-      try {
-        parseReleaseTag(tag);
-        return true;
-      } catch {
-        return false;
-      }
-    });
+  return getCoreSemverReleaseTags({ cwd, run });
 }
 
 export async function getReleaseVersionRecommendation({

--- a/scripts/release/recommend.mjs
+++ b/scripts/release/recommend.mjs
@@ -1,0 +1,352 @@
+import { execFileSync } from 'node:child_process';
+import { loadPackageJson, parseReleaseTag } from './core.mjs';
+
+const numericIdentifierPattern = /^[0-9]+$/u;
+const breakingChangeFooterPattern = /^BREAKING[ -]CHANGE:/mu;
+const conventionalBreakingSubjectPattern = /^[a-z][a-z0-9-]*(?:\([^)]+\))?!:/iu;
+const conventionalFeatureSubjectPattern = /^feat(?:\([^)]+\))?!?:/u;
+
+function runGit(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+function compareNumbers(left, right) {
+  return Math.sign(left - right);
+}
+
+function compareAscii(left, right) {
+  const length = Math.min(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const characterComparison = compareNumbers(left.charCodeAt(index), right.charCodeAt(index));
+
+    if (characterComparison !== 0) {
+      return characterComparison;
+    }
+  }
+
+  return compareNumbers(left.length, right.length);
+}
+
+function parseComparableVersion(version) {
+  const normalizedVersion = parseReleaseTag(version.startsWith('v') ? version : `v${version}`)
+    .version;
+  const prereleaseStartIndex = normalizedVersion.indexOf('-');
+  const coreVersion =
+    prereleaseStartIndex === -1
+      ? normalizedVersion
+      : normalizedVersion.slice(0, prereleaseStartIndex);
+  const prereleaseVersion =
+    prereleaseStartIndex === -1 ? '' : normalizedVersion.slice(prereleaseStartIndex + 1);
+  const [major, minor, patch] = coreVersion.split('.').map(Number);
+
+  if (![major, minor, patch].every(Number.isInteger)) {
+    throw new Error(`Release version '${version}' is invalid.`);
+  }
+
+  return {
+    coreVersion,
+    major,
+    minor,
+    patch,
+    prerelease: prereleaseVersion ? prereleaseVersion.split('.') : [],
+    version: normalizedVersion
+  };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  const leftIsNumeric = numericIdentifierPattern.test(left);
+  const rightIsNumeric = numericIdentifierPattern.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return compareNumbers(Number(left), Number(right));
+  }
+
+  if (leftIsNumeric) {
+    return -1;
+  }
+
+  if (rightIsNumeric) {
+    return 1;
+  }
+
+  return compareAscii(left, right);
+}
+
+function compareParsedVersions(left, right) {
+  const coreComparison =
+    compareNumbers(left.major, right.major) ||
+    compareNumbers(left.minor, right.minor) ||
+    compareNumbers(left.patch, right.patch);
+
+  if (coreComparison !== 0) {
+    return coreComparison;
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const identifierComparison = comparePrereleaseIdentifiers(leftIdentifier, rightIdentifier);
+    if (identifierComparison !== 0) {
+      return identifierComparison;
+    }
+  }
+
+  return 0;
+}
+
+function isStableVersion(parsedVersion) {
+  return parsedVersion.prerelease.length === 0;
+}
+
+function formatCoreVersion({ major, minor, patch }) {
+  return `${major}.${minor}.${patch}`;
+}
+
+function incrementVersion(version, bump) {
+  const parsedVersion = parseComparableVersion(version);
+
+  if (bump === 'major') {
+    return `${parsedVersion.major + 1}.0.0`;
+  }
+
+  if (bump === 'minor') {
+    return `${parsedVersion.major}.${parsedVersion.minor + 1}.0`;
+  }
+
+  return `${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch + 1}`;
+}
+
+function getLatestStableTag(tags) {
+  return tags
+    .map((tag) => ({ parsedTag: parseComparableVersion(tag), tag }))
+    .filter(({ parsedTag }) => isStableVersion(parsedTag))
+    .sort((left, right) => compareParsedVersions(right.parsedTag, left.parsedTag))[0]?.tag;
+}
+
+function getLatestSemverTag(tags) {
+  return tags
+    .map((tag) => ({ parsedTag: parseComparableVersion(tag), tag }))
+    .sort((left, right) => compareParsedVersions(right.parsedTag, left.parsedTag))[0]?.tag;
+}
+
+function getBaseVersion({ latestStableTag, packageVersion }) {
+  const parsedPackageVersion = parseComparableVersion(packageVersion);
+  const packageCoreVersion = formatCoreVersion(parsedPackageVersion);
+
+  if (!latestStableTag) {
+    return packageCoreVersion;
+  }
+
+  const latestStableVersion = parseReleaseTag(latestStableTag).version;
+  return compareParsedVersions(
+    parseComparableVersion(packageCoreVersion),
+    parseComparableVersion(latestStableVersion)
+  ) >= 0
+    ? packageCoreVersion
+    : latestStableVersion;
+}
+
+function getStableVersionForLatestPrerelease({ baseVersion, latestSemverTag }) {
+  if (!latestSemverTag) {
+    return null;
+  }
+
+  const latestSemverVersion = parseComparableVersion(latestSemverTag);
+  if (isStableVersion(latestSemverVersion)) {
+    return null;
+  }
+
+  const stableCandidate = parseComparableVersion(latestSemverVersion.coreVersion);
+  const base = parseComparableVersion(baseVersion);
+  return compareParsedVersions(stableCandidate, base) >= 0 ? stableCandidate.version : null;
+}
+
+function parseReleaseCommitRecord(record) {
+  const [hash, subject, message] = record.split('\0');
+
+  return {
+    hash,
+    message: message ?? subject ?? '',
+    subject: subject ?? ''
+  };
+}
+
+function getReleaseCommits({ cwd, fromTag, run = runGit } = {}) {
+  const range = fromTag ? `${fromTag}..HEAD` : 'HEAD';
+  const output = run(['log', '--no-merges', '--format=%H%x00%s%x00%B%x1e', range], cwd);
+
+  return output
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map(parseReleaseCommitRecord);
+}
+
+function deriveRecommendedBump({ commits, sourceLabel }) {
+  const breakingCommits = commits.filter(
+    ({ message, subject }) =>
+      conventionalBreakingSubjectPattern.test(subject) || breakingChangeFooterPattern.test(message)
+  );
+
+  if (breakingCommits.length > 0) {
+    return {
+      bump: 'major',
+      reason: `Found ${breakingCommits.length} breaking-change signal(s) since ${sourceLabel}.`
+    };
+  }
+
+  const featureCommits = commits.filter(({ subject }) =>
+    conventionalFeatureSubjectPattern.test(subject)
+  );
+
+  if (featureCommits.length > 0) {
+    return {
+      bump: 'minor',
+      reason: `Found ${featureCommits.length} feature commit(s) since ${sourceLabel}.`
+    };
+  }
+
+  if (commits.length > 0) {
+    return {
+      bump: 'patch',
+      reason: `Found ${commits.length} non-merge commit(s) since ${sourceLabel} without a stronger semver signal.`
+    };
+  }
+
+  return {
+    bump: 'patch',
+    reason: `No non-merge commits found since ${sourceLabel}; patch is the safest explicit default.`
+  };
+}
+
+function getNextRcVersion({ stableVersion, tags }) {
+  const target = parseComparableVersion(stableVersion);
+  const nextRcNumber =
+    tags
+      .map((tag) => parseComparableVersion(tag))
+      .filter(
+        (version) =>
+          version.major === target.major &&
+          version.minor === target.minor &&
+          version.patch === target.patch &&
+          version.prerelease.length === 2 &&
+          version.prerelease[0] === 'rc' &&
+          numericIdentifierPattern.test(version.prerelease[1])
+      )
+      .map((version) => Number(version.prerelease[1]))
+      .sort((left, right) => right - left)[0] ?? 0;
+
+  return `${stableVersion}-rc.${nextRcNumber + 1}`;
+}
+
+export function getSemverReleaseTags({ cwd = process.cwd(), run = runGit } = {}) {
+  const output = run(['tag', '--list', 'v*'], cwd);
+  return output
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .filter((tag) => {
+      try {
+        parseReleaseTag(tag);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+}
+
+export async function getReleaseVersionRecommendation({
+  cwd = process.cwd(),
+  run = runGit
+} = {}) {
+  const pkg = await loadPackageJson(cwd);
+  const tags = getSemverReleaseTags({ cwd, run });
+  const latestSemverTag = getLatestSemverTag(tags) ?? null;
+  const latestStableTag = getLatestStableTag(tags) ?? null;
+  const baseVersion = getBaseVersion({
+    latestStableTag,
+    packageVersion: pkg.version
+  });
+  const sourceLabel = latestSemverTag ?? 'the current repository state';
+  const sourceRange = latestSemverTag ? `${latestSemverTag}..HEAD` : 'HEAD';
+  const commits = getReleaseCommits({ cwd, fromTag: latestSemverTag, run });
+  const { bump, reason } = deriveRecommendedBump({ commits, sourceLabel });
+  const stableVersionForLatestPrerelease = getStableVersionForLatestPrerelease({
+    baseVersion,
+    latestSemverTag
+  });
+  const shouldFinaliseLatestPrerelease = bump === 'patch' && stableVersionForLatestPrerelease;
+  const recommendedVersion = shouldFinaliseLatestPrerelease
+    ? stableVersionForLatestPrerelease
+    : incrementVersion(baseVersion, bump);
+  const recommendedBump = shouldFinaliseLatestPrerelease ? 'stable' : bump;
+  const recommendationReason = shouldFinaliseLatestPrerelease
+    ? `Latest release tag ${latestSemverTag} is a prerelease for ${stableVersionForLatestPrerelease}; recommend finalising that stable version before bumping patch.`
+    : reason;
+  const alternatives = {
+    patch: incrementVersion(baseVersion, 'patch'),
+    minor: incrementVersion(baseVersion, 'minor'),
+    major: incrementVersion(baseVersion, 'major'),
+    releaseCandidate: getNextRcVersion({ stableVersion: recommendedVersion, tags })
+  };
+
+  return {
+    alternatives,
+    baseVersion,
+    commitCount: commits.length,
+    latestSemverTag,
+    latestStableTag,
+    packageName: pkg.name,
+    reason: recommendationReason,
+    recommendedBump,
+    recommendedVersion,
+    sourceRange
+  };
+}
+
+export function formatReleaseVersionRecommendation(recommendation) {
+  return [
+    'No release version supplied.',
+    '',
+    `Recommended next version: ${recommendation.recommendedVersion}`,
+    `Reason: ${recommendation.reason}`,
+    `Source: ${recommendation.sourceRange}`,
+    '',
+    'Alternatives:',
+    `- patch: ${recommendation.alternatives.patch}`,
+    `- minor: ${recommendation.alternatives.minor}`,
+    `- major: ${recommendation.alternatives.major}`,
+    `- release candidate: ${recommendation.alternatives.releaseCandidate}`,
+    '',
+    'Run:',
+    `  yarn release:prepare ${recommendation.recommendedVersion}`,
+    ''
+  ].join('\n');
+}

--- a/scripts/release/recommend.mjs
+++ b/scripts/release/recommend.mjs
@@ -294,7 +294,7 @@ export async function getReleaseVersionRecommendation({
     latestStableTag,
     packageVersion: pkg.version
   });
-  const sourceLabel = latestSemverTag ?? 'the current repository state';
+  const sourceLabel = latestSemverTag ?? 'the start of the repository history';
   const sourceRange = latestSemverTag ? `${latestSemverTag}..HEAD` : 'HEAD';
   const commits = getReleaseCommits({ cwd, fromTag: latestSemverTag, run });
   const { bump, reason } = deriveRecommendedBump({ commits, sourceLabel });

--- a/scripts/release/recommend.test.mjs
+++ b/scripts/release/recommend.test.mjs
@@ -27,7 +27,10 @@ async function createReleaseRepo({ packageVersion = '1.0.2', tag = 'v1.0.2' } = 
   );
   git(tempDir, ['add', 'package.json']);
   git(tempDir, ['commit', '-m', 'Initial release']);
-  git(tempDir, ['tag', tag]);
+
+  if (tag) {
+    git(tempDir, ['tag', tag]);
+  }
 
   return tempDir;
 }
@@ -88,6 +91,27 @@ test('getReleaseVersionRecommendation recommends minor for feat commits', async 
     assert.equal(recommendation.recommendedBump, 'minor');
     assert.equal(recommendation.recommendedVersion, '1.1.0');
     assert.equal(recommendation.alternatives.releaseCandidate, '1.1.0-rc.1');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getReleaseVersionRecommendation describes no-tag history clearly', async () => {
+  const tempDir = await createReleaseRepo({ packageVersion: '1.0.0', tag: null });
+
+  try {
+    await commitChange(tempDir, {
+      filename: 'first-feature.txt',
+      subject: 'feat: add first feature'
+    });
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedBump, 'minor');
+    assert.equal(recommendation.recommendedVersion, '1.1.0');
+    assert.equal(recommendation.sourceRange, 'HEAD');
+    assert.match(recommendation.reason, /since the start of the repository history/u);
+    assert.doesNotMatch(recommendation.reason, /current repository state/u);
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }

--- a/scripts/release/recommend.test.mjs
+++ b/scripts/release/recommend.test.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { getReleaseVersionRecommendation } from './recommend.mjs';
+
+function git(cwd, args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+async function createReleaseRepo({ packageVersion = '1.0.2', tag = 'v1.0.2' } = {}) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'release-recommend-'));
+
+  git(tempDir, ['init']);
+  git(tempDir, ['config', 'user.email', 'test@example.com']);
+  git(tempDir, ['config', 'user.name', 'Release Test']);
+
+  await writeFile(
+    path.join(tempDir, 'package.json'),
+    `${JSON.stringify({ name: '@smolpack/eslint-config', version: packageVersion }, null, 2)}\n`
+  );
+  git(tempDir, ['add', 'package.json']);
+  git(tempDir, ['commit', '-m', 'Initial release']);
+  git(tempDir, ['tag', tag]);
+
+  return tempDir;
+}
+
+async function writePackageJson(cwd, version) {
+  await writeFile(
+    path.join(cwd, 'package.json'),
+    `${JSON.stringify({ name: '@smolpack/eslint-config', version }, null, 2)}\n`
+  );
+}
+
+async function commitChange(cwd, { body = null, filename, subject }) {
+  await writeFile(path.join(cwd, filename), `${subject}\n`);
+  git(cwd, ['add', filename]);
+
+  if (body) {
+    git(cwd, ['commit', '-m', subject, '-m', body]);
+    return;
+  }
+
+  git(cwd, ['commit', '-m', subject]);
+}
+
+test('getReleaseVersionRecommendation falls back to patch for non-conventional commits', async () => {
+  const tempDir = await createReleaseRepo();
+
+  try {
+    await commitChange(tempDir, {
+      filename: 'release-workflow.txt',
+      subject: 'Improve release workflow'
+    });
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedBump, 'patch');
+    assert.equal(recommendation.recommendedVersion, '1.0.3');
+    assert.equal(recommendation.sourceRange, 'v1.0.2..HEAD');
+    assert.equal(recommendation.alternatives.patch, '1.0.3');
+    assert.equal(recommendation.alternatives.minor, '1.1.0');
+    assert.equal(recommendation.alternatives.major, '2.0.0');
+    assert.equal(recommendation.alternatives.releaseCandidate, '1.0.3-rc.1');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getReleaseVersionRecommendation recommends minor for feat commits', async () => {
+  const tempDir = await createReleaseRepo();
+
+  try {
+    await commitChange(tempDir, {
+      filename: 'feature.txt',
+      subject: 'feat: add shared config'
+    });
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedBump, 'minor');
+    assert.equal(recommendation.recommendedVersion, '1.1.0');
+    assert.equal(recommendation.alternatives.releaseCandidate, '1.1.0-rc.1');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getReleaseVersionRecommendation recommends major for bang breaking-change subjects', async () => {
+  const tempDir = await createReleaseRepo();
+
+  try {
+    await commitChange(tempDir, {
+      filename: 'breaking-subject.txt',
+      subject: 'feat!: remove legacy config'
+    });
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedBump, 'major');
+    assert.equal(recommendation.recommendedVersion, '2.0.0');
+    assert.equal(recommendation.alternatives.releaseCandidate, '2.0.0-rc.1');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getReleaseVersionRecommendation recommends major for BREAKING CHANGE messages', async () => {
+  const tempDir = await createReleaseRepo();
+
+  try {
+    await commitChange(tempDir, {
+      body: 'BREAKING CHANGE: consumers must update their imports.',
+      filename: 'breaking-body.txt',
+      subject: 'refactor: simplify exports'
+    });
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedBump, 'major');
+    assert.equal(recommendation.recommendedVersion, '2.0.0');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getReleaseVersionRecommendation increments existing release-candidate tags', async () => {
+  const tempDir = await createReleaseRepo();
+
+  try {
+    await commitChange(tempDir, {
+      filename: 'rc-one.txt',
+      subject: 'Prepare release candidate'
+    });
+    git(tempDir, ['tag', 'v1.0.3-rc.1']);
+
+    await commitChange(tempDir, {
+      filename: 'rc-two.txt',
+      subject: 'Polish release candidate'
+    });
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedVersion, '1.0.3');
+    assert.equal(recommendation.sourceRange, 'v1.0.3-rc.1..HEAD');
+    assert.equal(recommendation.alternatives.releaseCandidate, '1.0.3-rc.2');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test('getReleaseVersionRecommendation finalises the latest release candidate before bumping patch', async () => {
+  const tempDir = await createReleaseRepo();
+
+  try {
+    await writePackageJson(tempDir, '1.1.0-rc.1');
+    git(tempDir, ['add', 'package.json']);
+    git(tempDir, ['commit', '-m', 'Release v1.1.0-rc.1']);
+    git(tempDir, ['tag', 'v1.1.0-rc.1']);
+
+    const recommendation = await getReleaseVersionRecommendation({ cwd: tempDir });
+
+    assert.equal(recommendation.recommendedBump, 'stable');
+    assert.equal(recommendation.recommendedVersion, '1.1.0');
+    assert.equal(recommendation.sourceRange, 'v1.1.0-rc.1..HEAD');
+    assert.equal(recommendation.alternatives.patch, '1.1.1');
+    assert.equal(recommendation.alternatives.releaseCandidate, '1.1.0-rc.2');
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add a non-mutating recommendation path to `yarn release:prepare` when no version is supplied
- Infer patch, minor, major, and release-candidate suggestions from recent release history and Conventional Commits
- Handle prerelease tags so RCs can finalise their stable core version instead of skipping ahead
- Update the release docs to show the recommendation step before the explicit mutating release prep

## Testing
- Added focused unit coverage for recommendation inference, RC handling, and invalid explicit versions
- Added release-prep tests for the no-version recommendation path
- `yarn lint`, `yarn test`, and `env npm_config_cache=/tmp/npm-cache yarn prerelease` passed

## Summary by Sourcery

Introduce a non-mutating release-version recommendation flow to the release preparation script and update documentation to surface it in the standard release process.

New Features:
- Add a recommendation path to `yarn release:prepare` that infers the next release version when no explicit version is provided.
- Infer patch, minor, major, and release-candidate version suggestions from recent Conventional Commit history and existing tags, including prerelease handling.

Enhancements:
- Make release preparation helpers accept configurable CWD/log parameters to support reuse and testing.
- Improve release flow documentation to describe using the recommendation helper before performing a mutating release prepare step.

Tests:
- Add unit tests for the release version recommendation logic, including prerelease and release-candidate handling.
- Extend release prepare tests to cover the no-version recommendation path and validation of invalid explicit versions.